### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -66,6 +66,12 @@ const doc = {
       isVerified: true,
       role: "user",
     },
+    UserProfile: {
+      name: "John Doe",
+      avatar: "https://i.imgur.com/xcLTrkV.png",
+      gender: 'male',
+      socialMedia: [ { type: 'facebook', id: '1234567890' }, { type: 'twitter', id: 'johndoe' } ],
+    },
     Poll: {
       _id: "62e348927278654321000004",
       title: "最喜歡的水果？",
@@ -138,6 +144,59 @@ const doc = {
       role: "user",
       edited: false,
       updateTime: "2023-11-16T07:52:54.232Z",
+    },
+    // Error Response
+    ErrorTokenExpired: {
+      status: false,
+      message: "Token 已經過期或無效",
+    },
+    ErrorJsonWebToken: {
+      status: false,
+      message: "驗證失敗，請重新登入！",
+    },
+    ErrorTokenNotFound: {
+      status: false,
+      message: "缺少 Token",
+    },
+    ErrorUserNotFound: {
+      status: false,
+      message: "已無此使用者請重新註冊 | 請確認 Email 是否正確 | 此 Email 未註冊",
+    },
+    ErrorPasswordNotMatch: {
+      status: false,
+      message: "密碼不一致 | 密碼錯誤",
+    },
+    ErrorEmailFormat: {
+      status: false,
+      message: "Email 格式有誤，請確認輸入是否正確",
+    },
+    ErrorInputFormat: {
+      status: false,
+      message: "請確認輸入的欄位格式是否正確",
+    },
+    ErrorPasswordFormat: {
+      status: false,
+      message: "密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元",
+    },
+    ErrorEmailExist: {
+      status: false,
+      message: "此 Email 已註冊",
+    },
+    ErrorVerificationUrlExpired: {
+      status: false,
+      message: "無效的重設連結或已過期",
+    },
+    ErrorImageFormat: {
+      status: false,
+      message: "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB",
+    },
+    ErrorImageNotFound: {
+      status: false,
+      message: "請上傳檔案",
+    },
+    ErrorMemberNotFound: {
+      status: false,
+      message: "無此使用者請確認使用者 id 是否正確",
     },
   },
 };

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -81,20 +81,7 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "message": {
-                  "type": "string",
-                  "example": "密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元"
-                },
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorPasswordFormat"
             },
             "description": "Bad Request"
           }
@@ -167,26 +154,17 @@
                     "result": {
                       "type": "object",
                       "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "object"
-                        },
-                        "properties": {
+                        "authToken": {
                           "type": "object",
                           "properties": {
-                            "authToken": {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "example": "string"
-                                }
-                              }
-                            },
-                            "member": {
-                              "$ref": "#/definitions/User"
+                            "type": {
+                              "type": "string",
+                              "example": "string"
                             }
                           }
+                        },
+                        "member": {
+                          "$ref": "#/definitions/User"
                         }
                       }
                     }
@@ -201,90 +179,21 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorInputFormat"
             },
             "description": "登入失敗"
           },
-          "401": {
+          "403": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorPasswordNotMatch"
+            },
+            "description": "登入失敗"
+          },
+          "404": {
+            "schema": {
+              "$ref": "#/definitions/ErrorEmailNotFound"
             },
             "description": "帳號或密碼錯誤"
-          },
-          "500": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "登入失敗"
           }
         }
       }
@@ -321,59 +230,13 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorTokenNotFound"
             },
             "description": "登出失敗"
           },
-          "500": {
+          "403": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "example": "object"
-                },
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
             "description": "登出失敗"
           }
@@ -416,58 +279,13 @@
           },
           "401": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "驗證碼已過期，請重新登入！"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorTokenExpired"
             },
-            "description": "token 驗證失敗"
-          },
-          "403": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "請重新登入"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "取得使用者資訊失敗"
+            "description": "Token 已經過期或無效"
           },
           "404": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "已無此使用者請重新註冊"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorUserNotFound"
             },
             "description": "取得使用者資訊失敗"
           }
@@ -524,39 +342,13 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "Email 格式有誤，請確認輸入是否正確"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorEmailFormat"
             },
             "description": "重設密碼失敗"
           },
           "404": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "此 Email 未註冊"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorUserNotFound"
             },
             "description": "重設密碼失敗"
           }
@@ -614,39 +406,13 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "無效的 token"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
             "description": "重設密碼失敗"
           },
           "404": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "無效的重設連結或已過期"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorVerificationUrlExpired"
             },
             "description": "重設密碼失敗"
           }
@@ -706,77 +472,25 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "密碼不一致"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorPasswordNotMatch"
             },
             "description": "更新密碼失敗"
           },
           "401": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "驗證碼已過期，請重新登入！"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorTokenExpired"
             },
-            "description": "token 驗證失敗"
+            "description": "Token 已經過期或無效"
           },
           "403": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "請重新登入"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
-            "description": "更新密碼失敗"
+            "description": "驗證失敗"
           },
           "404": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "已無此使用者請重新註冊"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorUserNotFound"
             },
             "description": "更新密碼失敗"
           }
@@ -832,58 +546,13 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "無效的 token"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
             "description": "驗證帳號失敗"
           },
           "404": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "無效的驗證連結或已過期"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
-            },
-            "description": "驗證帳號失敗"
-          },
-          "500": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "驗證失敗"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorVerificationUrlExpired"
             },
             "description": "驗證帳號失敗"
           }
@@ -928,89 +597,72 @@
           },
           "400": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "boolean",
-                  "example": false
-                },
-                "message": {
-                  "type": "string",
-                  "example": "信件格式錯誤"
-                }
-              },
-              "xml": {
-                "name": "main"
-              }
+              "$ref": "#/definitions/ErrorEmailFormat"
             },
             "description": "重新發送驗證 Email 失敗"
           }
         }
       }
     },
-    "/api/imgur/": {
+    "/api/imgur/upload": {
       "post": {
         "tags": [
           "Imgur - 圖片"
         ],
         "description": "上傳圖片",
+        "consumes": [
+          "multipart/form-data"
+        ],
         "parameters": [
           {
-            "name": "body",
-            "in": "body",
+            "name": "upload-image",
+            "in": "formData",
+            "type": "file",
             "required": true,
-            "description": "上傳圖片",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "image": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "description": "上傳圖片"
           }
         ],
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Success"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "上傳成功"
+                },
+                "result": {
+                  "type": "string",
+                  "example": "https://i.imgur.com/xcLTrkV.png"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
             },
             "description": "上傳成功"
           },
-          "400": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "上傳失敗"
-          },
           "401": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
             "description": "未登入"
           },
-          "403": {
+          "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorImageNotFound"
             },
-            "description": "圖片格式錯誤"
+            "description": "請上傳檔案"
           },
           "500": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorImageFormat"
             },
-            "description": "上傳失敗"
+            "description": "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB"
           }
         },
         "security": [
@@ -1045,15 +697,45 @@
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Member"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "成功取得使用者列表"
+                },
+                "result": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Member"
+                      }
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "currentPage": {
+                      "type": "number",
+                      "example": 1
+                    },
+                    "totalCount": {
+                      "type": "number",
+                      "example": 1
+                    }
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
             },
             "description": "獲取會員列表成功"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "獲取會員列表失敗"
           }
         }
       },
@@ -1069,53 +751,36 @@
             "required": true,
             "description": "更新會員資料",
             "schema": {
-              "type": "object",
-              "properties": {
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    },
-                    "updateData": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "object"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              "$ref": "#/definitions/MemberProfile"
             }
           }
         ],
         "responses": {
           "200": {
             "schema": {
+              "status": true,
+              "message": "成功更新使用者資訊！",
               "$ref": "#/definitions/Member"
             },
             "description": "更新會員資料成功"
           },
+          "401": {
+            "schema": {
+              "$ref": "#/definitions/ErrorTokenExpired"
+            },
+            "description": "Token 已經過期或無效"
+          },
+          "403": {
+            "schema": {
+              "$ref": "#/definitions/ErrorJsonWebToken"
+            },
+            "description": "驗證失敗"
+          },
           "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorUserNotFound"
             },
             "description": "找不到會員"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "更新會員資料失敗"
           }
         },
         "security": [
@@ -1143,21 +808,31 @@
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Member"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "成功取的使用者資訊"
+                },
+                "result": {
+                  "$ref": "#/definitions/Member"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
             },
             "description": "獲取會員詳情成功"
           },
           "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorMemberNotFound"
             },
             "description": "找不到會員"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "獲取會員詳情失敗"
           }
         }
       },
@@ -1178,63 +853,41 @@
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Member"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "成功刪除使用者"
+                },
+                "result": {}
+              },
+              "xml": {
+                "name": "main"
+              }
             },
             "description": "刪除會員成功"
           },
-          "404": {
+          "401": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorTokenExpired"
             },
-            "description": "找不到會員"
+            "description": "Token 已經過期或無效"
           },
-          "500": {
+          "403": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorJsonWebToken"
             },
-            "description": "刪除會員失敗"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      }
-    },
-    "/api/member/follow": {
-      "get": {
-        "tags": [
-          "Member - 會員"
-        ],
-        "description": "獲取會員追蹤者",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string",
-            "description": "會員ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "schema": {
-              "$ref": "#/definitions/Member"
-            },
-            "description": "獲取會員追蹤者成功"
+            "description": "驗證失敗"
           },
           "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorMemberNotFound"
             },
             "description": "找不到會員"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "獲取會員追蹤者失敗"
           }
         },
         "security": [
@@ -1249,7 +902,7 @@
         "tags": [
           "Member - 會員"
         ],
-        "description": "獲取會員追蹤中的人",
+        "description": "加入追蹤",
         "parameters": [
           {
             "name": "id",
@@ -1262,21 +915,50 @@
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Member"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "您已成功追蹤"
+                },
+                "result": {
+                  "$ref": "#/definitions/Member"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
             },
-            "description": "獲取會員追蹤中的人成功"
+            "description": "成功加入會員追蹤中的人"
+          },
+          "401": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "您無法追蹤自己"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "加入追蹤失敗"
           },
           "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorMemberNotFound"
             },
             "description": "找不到會員"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "獲取會員追蹤中的人失敗"
           }
         },
         "security": [
@@ -1302,21 +984,50 @@
         "responses": {
           "200": {
             "schema": {
-              "$ref": "#/definitions/Member"
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "取消追蹤成功"
+                },
+                "result": {
+                  "$ref": "#/definitions/Member"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
             },
             "description": "取消追蹤成功"
           },
+          "401": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "您無法取消追蹤自己"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "加入追蹤失敗"
+          },
           "404": {
             "schema": {
-              "$ref": "#/definitions/Error"
+              "$ref": "#/definitions/ErrorMemberNotFound"
             },
             "description": "找不到會員"
-          },
-          "500": {
-            "schema": {
-              "$ref": "#/definitions/Error"
-            },
-            "description": "取消追蹤失敗"
           }
         },
         "security": [
@@ -2671,6 +2382,39 @@
         }
       }
     },
+    "UserProfile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Doe"
+        },
+        "avatar": {
+          "type": "string",
+          "example": "https://i.imgur.com/xcLTrkV.png"
+        },
+        "gender": {
+          "type": "string",
+          "example": "male"
+        },
+        "socialMedia": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "example": "twitter"
+              },
+              "id": {
+                "type": "string",
+                "example": "johndoe"
+              }
+            }
+          }
+        }
+      }
+    },
     "Poll": {
       "type": "object",
       "properties": {
@@ -2883,6 +2627,175 @@
         "updateTime": {
           "type": "string",
           "example": "2023-11-16T07:52:54.232Z"
+        }
+      }
+    },
+    "ErrorTokenExpired": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "Token 已經過期或無效"
+        }
+      }
+    },
+    "ErrorJsonWebToken": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "驗證失敗，請重新登入！"
+        }
+      }
+    },
+    "ErrorTokenNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "缺少 Token"
+        }
+      }
+    },
+    "ErrorUserNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "已無此使用者請重新註冊 | 請確認 Email 是否正確 | 此 Email 未註冊"
+        }
+      }
+    },
+    "ErrorPasswordNotMatch": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "密碼不一致 | 密碼錯誤"
+        }
+      }
+    },
+    "ErrorEmailFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "Email 格式有誤，請確認輸入是否正確"
+        }
+      }
+    },
+    "ErrorInputFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "請確認輸入的欄位格式是否正確"
+        }
+      }
+    },
+    "ErrorPasswordFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元"
+        }
+      }
+    },
+    "ErrorEmailExist": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "此 Email 已註冊"
+        }
+      }
+    },
+    "ErrorVerificationUrlExpired": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "無效的重設連結或已過期"
+        }
+      }
+    },
+    "ErrorImageFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB"
+        }
+      }
+    },
+    "ErrorImageNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "請上傳檔案"
+        }
+      }
+    },
+    "ErrorMemberNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "無此使用者請確認使用者 id 是否正確"
         }
       }
     }

--- a/src/controllers/imgur.controller.ts
+++ b/src/controllers/imgur.controller.ts
@@ -19,24 +19,25 @@ export const upload = multer({
   {
     const ext = path.extname(file.originalname).toLowerCase();
     if (ext !== '.jpg' && ext !== '.png' && ext !== '.jpeg') {
-      cb(Error('檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。'));
+      cb(Error('檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB'));
     }
     cb(null, true);
   },
 }).any();
 // 將文件上傳的中間件和後續處理分開
 class ImgurController {
-  public static async createImgurHandler(req: Request, res: Response, next: NextFunction) {
+  public static async createImgurHandler(req: Request, res: Response, next: NextFunction)
+  {
     try {
-      if (!req.files) {
-        throw appError({ code: 400, message: '請上傳檔案', next });
+      if (!req.files?.length) {
+        throw appError({ code: 404, message: '請上傳檔案', next });
         }
         const response = await client.upload({
           image: req.files[0].buffer.toString('base64'),
           type: 'base64',
           album: process.env.IMGUR_ALBUM_ID,
         });
-        successHandle(res, 'Successfully uploaded to imgur', { result: response.data.link });
+        successHandle(res, '成功上傳圖片', { result: response.data.link });
       } catch (error) {
         if (error instanceof Error) {
           appError({ code: 500, message: error.message, next });

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -123,8 +123,11 @@ const userSchema = new Schema<IUser>(
   {
     versionKey: false,
     timestamps: true,
+    toJSON: {
+      virtuals: true
+    },
     toObject: {
-      virtuals: true,
+        virtuals: true
     },
   },
 );

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -31,32 +31,28 @@ authRouter.post(
       }
     * #swagger.responses[400] = {
         schema: {
-            message: '此 Email 已註冊',
-            status: false,
+            $ref: "#/definitions/ErrorEmailExist",
           },
         },
         description: "註冊失敗"
       }
     * #swagger.responses[400] = {
         schema: {
-            message: '密碼不一致',
-            status: false,
+            $ref: "#/definitions/ErrorPasswordNotMatch",
           },
         },
         description: "註冊失敗"
       }
     * #swagger.responses[400] = {
         schema: {
-            message: '請確認輸入的欄位格式是否正確',
-            status: false,
+            $ref: "#/definitions/ErrorInputFormat",
           },
         },
         description: "註冊失敗"
       }
     * #swagger.responses[400] = {
         schema: {
-            message: '密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元',
-            status: false,
+            $ref: "#/definitions/ErrorPasswordFormat",
           },
         },
         description: "註冊失敗"
@@ -85,11 +81,8 @@ authRouter.post(
           properties: {
             message: { type: 'string' },
             result: {
-              type: 'object',
-              properties: {
-                authToken: { type: 'string' },
-                member: { $ref: "#/definitions/User" },
-              },
+              authToken: { type: 'string' },
+              member: { $ref: "#/definitions/User" },
             },
           },
         },
@@ -97,30 +90,21 @@ authRouter.post(
       }
     * #swagger.responses[400] = {
         schema: {
-          type: 'object',
-          properties: {
-            message: { type: 'string' },
-          },
+          $ref: "#/definitions/ErrorInputFormat"
         },
         description: "登入失敗"
       }
-    * #swagger.responses[401] = {
-        schema: {
-          type: 'object',
-          properties: {
-            message: { type: 'string' },
+      * #swagger.responses[403] = {
+          schema: {
+            $ref: "#/definitions/ErrorPasswordNotMatch"
           },
+          description: "登入失敗"
+        }
+    * #swagger.responses[404] = {
+        schema: {
+          $ref: "#/definitions/ErrorEmailNotFound"
         },
         description: "帳號或密碼錯誤"
-      }
-    * #swagger.responses[500] = {
-        schema: {
-          type: 'object',
-          properties: {
-            message: { type: 'string' },
-          },
-        },
-        description: "登入失敗"
       }
    */
   '/login', handleErrorAsync(AuthController.loginHandler));
@@ -138,26 +122,13 @@ authRouter.get(
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '缺少 token',
+      $ref: "#/definitions/ErrorTokenNotFound"
     },
     description: "登出失敗"
   }
-  * #swagger.responses[400] = {
+  * #swagger.responses[403] = {
     schema: {
-      type: 'object',
-      properties: {
-        message: { type: 'string' },
-      },
-    },
-    description: "登出失敗"
-  }
-  * #swagger.responses[500] = {
-    schema: {
-      type: 'object',
-      properties: {
-        message: { type: 'string' },
-      },
+    $ref: "#/definitions/ErrorJsonWebToken"
     },
     description: "登出失敗"
   }
@@ -178,36 +149,13 @@ authRouter.get(
     }
   * #swagger.responses[401] = {
     schema: {
-        status: false,
-        message: 'Token 已經過期或無效',
+        $ref: "#/definitions/ErrorTokenExpired"
     },
     description: "Token 已經過期或無效"
   }
-  * #swagger.responses[401] = {
-    schema: {
-      status: false,
-      message: '驗證失敗，請重新登入！',
-    },
-    description: "token 驗證失敗"
-  }
-  * #swagger.responses[401] = {
-    schema: {
-      status: false,
-      message: '驗證碼已過期，請重新登入！',
-    },
-    description: "token 驗證失敗"
-  }
-  * #swagger.responses[403] = {
-    schema: {
-      status: false,
-      message: '請重新登入',
-    },
-    description: "取得使用者資訊失敗"
-  }
   * #swagger.responses[404] = {
     schema: {
-      status: false,
-      message: '已無此使用者請重新註冊',
+      $ref: "#/definitions/ErrorUserNotFound"
     },
     description: "取得使用者資訊失敗"
   }
@@ -236,15 +184,13 @@ authRouter.post(
   }
   * #swagger.responses[404] = {
     schema: {
-      status: false,
-      message: '此 Email 未註冊',
+      $ref: "#/definitions/ErrorUserNotFound"
     },
     description: "重設密碼失敗"
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: 'Email 格式有誤，請確認輸入是否正確',
+      $ref: "#/definitions/ErrorEmailFormat"
     },
     description: "重設密碼失敗"
   }
@@ -274,43 +220,25 @@ authRouter.post(
     }
     * #swagger.responses[400] = {
       schema: {
-        status: false,
-        message: '密碼不一致',
+        $ref: "#/definitions/ErrorPasswordNotMatch"
       },
       description: "更新密碼失敗"
     }
     * #swagger.responses[401] = {
     schema: {
-        status: false,
-        message: 'Token 已經過期或無效',
+        $ref: "#/definitions/ErrorTokenExpired"
     },
     description: "Token 已經過期或無效"
   }
-  * #swagger.responses[401] = {
-    schema: {
-      status: false,
-      message: '驗證失敗，請重新登入！',
-    },
-    description: "token 驗證失敗"
-  }
-  * #swagger.responses[401] = {
-    schema: {
-      status: false,
-      message: '驗證碼已過期，請重新登入！',
-    },
-    description: "token 驗證失敗"
-  }
   * #swagger.responses[403] = {
     schema: {
-      status: false,
-      message: '請重新登入',
+      $ref: "#/definitions/ErrorJsonWebToken"
     },
-    description: "更新密碼失敗"
+    description: "驗證失敗"
   }
   * #swagger.responses[404] = {
     schema: {
-      status: false,
-      message: '已無此使用者請重新註冊',
+    $ref: "#/definitions/ErrorUserNotFound"
     },
     description: "更新密碼失敗"
   }
@@ -341,29 +269,25 @@ authRouter.put(
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '密碼不一致',
+    $ref: "#/definitions/ErrorPasswordNotMatch"
     },
     description: "重設密碼失敗"
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '缺少 token',
+    $ref: "#/definitions/ErrorTokenNotFound"
     },
     description: "重設密碼失敗"
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '無效的 token',
+    $ref: "#/definitions/ErrorJsonWebToken"
     },
     description: "重設密碼失敗"
   }
   * #swagger.responses[404] = {
     schema: {
-      status: false,
-      message: '無效的重設連結或已過期',
+    $ref: "#/definitions/ErrorVerificationUrlExpired"
     },
     description: "重設密碼失敗"
   }
@@ -392,31 +316,22 @@ authRouter.get(
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '缺少 token',
+      $ref: "#/definitions/ErrorTokenNotFound"
     },
     description: "驗證帳號失敗"
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '無效的 token',
+    $ref: "#/definitions/ErrorJsonWebToken"
     },
     description: "驗證帳號失敗"
   }
   * #swagger.responses[404] = {
     schema: {
-      status: false,
-      message: '無效的驗證連結或已過期',
+    $ref: "#/definitions/ErrorVerificationUrlExpired"
     },
     description: "驗證帳號失敗"
   }
-  * #swagger.responses[500] = {
-    schema: {
-      status: false,
-      message: '驗證失敗',
-    },
-    description: "驗證帳號失敗"
   }
    */
   '/verify', handleErrorAsync(AuthController.verifyAccount));
@@ -437,15 +352,13 @@ authRouter.post(
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '無此帳號，請再次確認註冊 Email 帳號，或是重新註冊新帳號',
+    $ref: "#/definitions/ErrorEmailNotFound"
     },
     description: "重新發送驗證 Email 失敗"
   }
   * #swagger.responses[400] = {
     schema: {
-      status: false,
-      message: '信件格式錯誤',
+    $ref: "#/definitions/ErrorEmailFormat"
     },
     description: "重新發送驗證 Email 失敗"
   }

--- a/src/routes/imgur.router.ts
+++ b/src/routes/imgur.router.ts
@@ -9,40 +9,41 @@ imgurRouter.post(
   /**
    * #swagger.tags = ['Imgur - 圖片']
    * #swagger.description = '上傳圖片'
-   * #swagger.parameters['body'] = {
-  in: 'body',
-  required: true,
-  type: 'object',
-  description: '上傳圖片',
-  schema: {
-    properties: {
-      image: { type: "string" }
+   * #swagger.consumes = ['multipart/form-data']
+   * #swagger.parameters['singleFile'] = {
+            in: 'formData',
+            type: 'file',
+            required: 'true',
+            description: '上傳圖片',
+            name: 'upload-image'
     }
   }
 }
    * #swagger.responses[200] = {
-      schema: { $ref: "#/definitions/Success" },
+      schema: {
+        status: true,
+        message: '上傳成功',
+        result: 'https://i.imgur.com/xcLTrkV.png'
+      },
       description: "上傳成功"
     }
-   * #swagger.responses[400] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "上傳失敗"
-    }
-  * #swagger.responses[401] = {
-      schema: { $ref: "#/definitions/Error" },
+    * #swagger.responses[401] = {
+      schema: {
+        $ref: "#/definitions/ErrorJsonWebToken"
+      },
       description: "未登入"
     }
-    * #swagger.responses[403] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "圖片格式錯誤"
+   * #swagger.responses[404] = {
+      schema: { $ref: "#/definitions/ErrorImageNotFound" },
+      description: "請上傳檔案"
     }
     * #swagger.responses[500] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "上傳失敗"
+      schema: { $ref: "#/definitions/ErrorImageFormat" },
+      description: "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB"
     }
     * #swagger.security = [{ "Bearer": [] }]
    */
-  '/',
+  '/upload',
   upload,
   handleErrorAsync(ImgurController.createImgurHandler)
 );

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,9 +12,10 @@ const apiRouter = Router();
 
 apiRouter.use((req: Request, _, next: NextFunction) => {
   Logger.trace(
-    `req ${req.path} query ${JSON.stringify(req.query)} body ${JSON.stringify(
-      req.body,
-    )} in api router`,
+    `req ${req.path} query ${JSON.stringify(req.query)} ${ process.env.NODE_ENV === 'development' ? `body ${
+      JSON.stringify(
+        req.body,
+      )}` : ''} ${JSON.stringify(req.params)} in api router`,
   );
   next();
 });

--- a/src/routes/member.router.ts
+++ b/src/routes/member.router.ts
@@ -22,12 +22,19 @@ memberRouter.get(
         description: '每頁記錄數',
       }
     * #swagger.responses[200] = {
-        schema: { $ref: "#/definitions/Member" },
+        schema: {
+          status: true,
+          message: "成功取得使用者列表",
+          result: {
+              users: [
+            {$ref: "#/definitions/Member"},
+            ],
+            totalPages: 1,
+            currentPage: 1,
+            totalCount: 1,
+          },
+        },
         description: "獲取會員列表成功"
-      }
-    * #swagger.responses[500] = {
-        schema: { $ref: "#/definitions/Error" },
-        description: "獲取會員列表失敗"
       }
    */
   '/', handleErrorAsync(MemberController.getAllMembers));
@@ -42,16 +49,18 @@ memberRouter.get(
     description: '會員ID'
     }
     * #swagger.responses[200] = {
-        schema: { $ref: "#/definitions/Member" },
+        schema: {
+          status: true,
+          message: "成功取的使用者資訊",
+          result: {
+          $ref: "#/definitions/Member"
+          }
+        },
         description: "獲取會員詳情成功"
       }
     * #swagger.responses[404] = {
-        schema: { $ref: "#/definitions/Error" },
+        schema: { $ref: "#/definitions/ErrorMemberNotFound" },
         description: "找不到會員"
-      }
-    * #swagger.responses[500] = {
-        schema: { $ref: "#/definitions/Error" },
-        description: "獲取會員詳情失敗"
       }
    */
   '/:id', handleErrorAsync(MemberController.getMemberById));
@@ -65,24 +74,33 @@ memberRouter.put(
       type: 'object',
       description: '更新會員資料',
       schema: {
-        properties: {
-          id: { type: 'string' },
-          updateData: { type: 'object' },
-        },
+        $ref: "#/definitions/MemberProfile",
       },
     }
     * #swagger.responses[200] = {
-        schema: { $ref: "#/definitions/Member" },
+        schema: {
+          status: true,
+          message: "成功更新使用者資訊！",
+          $ref: "#/definitions/Member"
+        },
         description: "更新會員資料成功"
       }
     * #swagger.responses[404] = {
-        schema: { $ref: "#/definitions/Error" },
+        schema: { $ref: "#/definitions/ErrorUserNotFound" },
         description: "找不到會員"
       }
-    * #swagger.responses[500] = {
-        schema: { $ref: "#/definitions/Error" },
-        description: "更新會員資料失敗"
-      }
+    * #swagger.responses[401] = {
+    schema: {
+        $ref: "#/definitions/ErrorTokenExpired"
+    },
+    description: "Token 已經過期或無效"
+  }
+  * #swagger.responses[403] = {
+    schema: {
+      $ref: "#/definitions/ErrorJsonWebToken"
+    },
+    description: "驗證失敗"
+  }
     * #swagger.security = [{
         "Bearer": []
       }]
@@ -99,17 +117,29 @@ memberRouter.delete(
     description: '會員ID'
   }
   * #swagger.responses[200] = {
-      schema: { $ref: "#/definitions/Member" },
+      schema: {
+        status: true,
+        message: "成功刪除使用者",
+        result: null,
+      },
       description: "刪除會員成功"
     }
   * #swagger.responses[404] = {
-      schema: { $ref: "#/definitions/Error" },
+      schema: { $ref: "#/definitions/ErrorMemberNotFound" },
       description: "找不到會員"
     }
-  * #swagger.responses[500] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "刪除會員失敗"
-    }
+  * #swagger.responses[401] = {
+    schema: {
+        $ref: "#/definitions/ErrorTokenExpired"
+    },
+    description: "Token 已經過期或無效"
+  }
+  * #swagger.responses[403] = {
+    schema: {
+      $ref: "#/definitions/ErrorJsonWebToken"
+    },
+    description: "驗證失敗"
+  }
   * #swagger.security = [{
       "Bearer": []
     }]
@@ -118,7 +148,7 @@ memberRouter.delete(
 memberRouter.get(
   /**
    * #swagger.tags = ['Member - 會員']
-   * #swagger.description = '獲取會員追蹤者'
+   * #swagger.description = '加入追蹤'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -126,43 +156,23 @@ memberRouter.get(
     description: '會員ID'
   }
   * #swagger.responses[200] = {
-      schema: { $ref: "#/definitions/Member" },
-      description: "獲取會員追蹤者成功"
+      schema: {
+      status: true,
+        message: "您已成功追蹤",
+        result: { $ref: "#/definitions/Member" },
+      },
+      description: "成功加入會員追蹤中的人"
     }
-  * #swagger.responses[404] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "找不到會員"
-    }
-  * #swagger.responses[500] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "獲取會員追蹤者失敗"
-    }
-  * #swagger.security = [{
-      "Bearer": []
-    }]
-    */
-  '/follow',  handleErrorAsync(MemberController.getFollowers));
-memberRouter.get(
-  /**
-   * #swagger.tags = ['Member - 會員']
-   * #swagger.description = '獲取會員追蹤中的人'
-   * #swagger.parameters['id'] = {
-    in: 'path',
-    required: true,
-    type: 'string',
-    description: '會員ID'
+  * #swagger.responses[401] = {
+    schema: {
+        status: false,
+        message: "您無法追蹤自己",
+    },
+    description: "加入追蹤失敗"
   }
-  * #swagger.responses[200] = {
-      schema: { $ref: "#/definitions/Member" },
-      description: "獲取會員追蹤中的人成功"
-    }
   * #swagger.responses[404] = {
-      schema: { $ref: "#/definitions/Error" },
+      schema: { $ref: "#/definitions/ErrorMemberNotFound" },
       description: "找不到會員"
-    }
-  * #swagger.responses[500] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "獲取會員追蹤中的人失敗"
     }
   * #swagger.security = [{
       "Bearer": []
@@ -180,16 +190,23 @@ memberRouter.delete(
     description: '會員ID'
   }
   * #swagger.responses[200] = {
-      schema: { $ref: "#/definitions/Member" },
+      schema: {
+        status: true,
+        message: "取消追蹤成功",
+        result: { $ref: "#/definitions/Member" },
+      },
       description: "取消追蹤成功"
     }
+  * #swagger.responses[401] = {
+    schema: {
+        status: false,
+        message: "您無法取消追蹤自己",
+    },
+    description: "加入追蹤失敗"
+  }
   * #swagger.responses[404] = {
-      schema: { $ref: "#/definitions/Error" },
+      schema: { $ref: "#/definitions/ErrorMemberNotFound" },
       description: "找不到會員"
-    }
-  * #swagger.responses[500] = {
-      schema: { $ref: "#/definitions/Error" },
-      description: "取消追蹤失敗"
     }
   * #swagger.security = [{
       "Bearer": []

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -32,12 +32,12 @@ export class AuthService {
     const { email, password } = options;
     const member = await AuthService.getMemberByAccountOrEmail(email);
     if (!member) {
-      throw appError({ code: 404, message: 'no such member', next });
+      throw appError({ code: 404, message: '請確認 Email 是否正確', next });
     }
 
     // check password
     if (member.password && !AuthService.verifyPassword(password, member.password)) {
-      throw appError({ code: 403, message: 'password does not match', next });
+      throw appError({ code: 403, message: '密碼錯誤', next });
     }
 
     const publicMember: Omit<Member, 'passhash'> = {
@@ -92,7 +92,7 @@ export class AuthService {
 
   static getMemberByAccountOrEmail = async (email: string): Promise<Member | null> =>
   {
-    const userDocument = await User.findOne({ email }).select('email name password avatar').exec();
+    const userDocument = await User.findOne({ email }).exec();
 
     if (!userDocument) return null;
 
@@ -142,7 +142,7 @@ export class AuthService {
 
   static updatePassword = async ({ email, password, next }: { email: string; password: string; next: NextFunction }) => {
     try {
-      const user = await User.findById(email);
+      const user = await User.findOne({ email });
       if (!user) {
         throw appError({ code: 404, message: '此 Email 未註冊', next });
       }
@@ -153,6 +153,16 @@ export class AuthService {
       throw appError({ message: (error as Error).message, next });
     }
   };
+
+  static deleteMemberById = async (id: string, next: NextFunction) => {
+    try {
+      const user = await User.findByIdAndDelete(id).exec();
+      if (!user) throw appError({ code: 404, message: '無此使用者請確認使用者 id 是否正確', next });
+      return user;
+    } catch (error) {
+      throw appError({ message: (error as Error).message, next });
+    }
+  }
 
   static updateValidationToken = () =>
   {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,7 +23,7 @@ export const verifyToken = (token: string) => {
   } catch (error) {
     return appError({
       code: 403,
-      message: '請重新登入',
+      message: '驗證失敗，請重新登入！',
     });
   }
 };


### PR DESCRIPTION
功能：重構 API 錯誤處理和文件

- 在 swagger.ts 文件中新增一個 UserProfile 物件，包含姓名、頭像、性別和社交媒體欄位。
- 在 swagger.ts 文件中新增多個錯誤響應物件，用於處理令牌過期、JWT 錯誤、缺失令牌、用戶未找到、密碼不匹配、電子郵件格式不正確、輸入格式不正確、密碼格式錯誤、電子郵件存在性、驗證 URL 過期、圖片格式錯誤以及遺失圖片的錯誤。
- 修正 imgur.controller.ts 文件中上傳方法的控制台日志中的一個打字錯誤。
- 修改 ImgurController 的 createImgurHandler 方法，以檢查是否有檔案上傳並正確地處理錯誤。
- 修改 MemberController 的 getAllMembers 方法來管理分頁，並在響應中新增總頁數、當前頁和總計數。
- 修改 MemberController 的 getMemberById 方法以處理資源未找到的錯誤。
- 修改 MemberController 的 deleteMemberById 方法，使用 AuthService.deleteMemberById。
- 修改 MemberController 的 addFollower 和 deleteFollower 方法以管理關注/取消關注功能，並處理資源未找到的錯誤。
- 在用戶模型的 schema 的 toJSON 方法中新增虛擬属性。
- 在 auth.controller.ts 文件中修正 registerHandler 和 changePasswordHandler 方法，以發送適當的錯誤信息。
- 在 AuthService 類中為各種方法（包括登入、更新密碼和刪除成員）新增新的錯誤消息。
- 在各控制器文件的不同方法中新增明確的 catch 區塊進行錯誤處理。
- 完善 auth.router.ts、imgur.router.ts 和 member.router.ts 中的 swagger 文檔，參照正確的錯誤定義並準確描述 API 端點。