### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -7,7 +7,7 @@ const doc = {
     title: "Select Wave 選集 API 系統 - Swagger",
     description: `部分API需求 \n注意事項：登入成功後請點「Authorize」輸入 Token。\n\n範例程式碼 :
 
-    fetch('/api/auth/check', { method: 'GET', headers: {
+    fetch(\`\${baseUrl}/api/auth/check\`, { method: 'GET', headers: {
         'Authorization': 'Bearer ' + token
     }})
       .then(response => response.json())
@@ -162,6 +162,7 @@ const doc = {
       options: [],
       like: [],
       comments: [],
+      status: "active",
     },
     OptionCreate: {
       title: "React",

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Select Wave 選集 API 系統 - Swagger",
-    "description": "部分API需求 \n注意事項：登入成功後請點「Authorize」輸入 Token。\n\n範例程式碼 :\n\n    fetch('/api/auth/check', { method: 'GET', headers: {\n        'Authorization': 'Bearer ' + token\n    }})\n      .then(response => response.json())\n      .then(res => {\n          // { status: 'true', result: [{...}] }\n          console.log(res);\n      });\n    ",
+    "description": "部分API需求 \n注意事項：登入成功後請點「Authorize」輸入 Token。\n\n範例程式碼 :\n\n    fetch(`${baseUrl}/api/auth/check`, { method: 'GET', headers: {\n        'Authorization': 'Bearer ' + token\n    }})\n      .then(response => response.json())\n      .then(res => {\n          // { status: 'true', result: [{...}] }\n          console.log(res);\n      });\n    ",
     "version": "1.0.0"
   },
   "host": "localhost:3000",
@@ -604,7 +604,7 @@
         }
       }
     },
-    "/api/imgur/upload": {
+    "/imgur/upload": {
       "post": {
         "tags": [
           "Imgur - 圖片"
@@ -1046,7 +1046,7 @@
         ]
       }
     },
-    "/api/poll/": {
+    "/poll/": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1082,7 +1082,10 @@
                   "example": "獲取投票列表成功"
                 },
                 "result": {
-                  "$ref": "#/definitions/Poll"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Poll"
+                  }
                 }
               },
               "xml": {
@@ -1146,7 +1149,7 @@
         ]
       }
     },
-    "/api/poll/{id}": {
+    "/poll/{id}": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1314,8 +1317,8 @@
         ]
       }
     },
-    "/api/poll/{id}/like": {
-      "post": {
+    "/poll/{id}/like": {
+      "get": {
         "tags": [
           "Poll - 投票"
         ],
@@ -1364,9 +1367,7 @@
             "Bearer": []
           }
         ]
-      }
-    },
-    "/api/poll/{id}/unlike": {
+      },
       "delete": {
         "tags": [
           "Poll - 投票"
@@ -1418,7 +1419,7 @@
         ]
       }
     },
-    "/api/poll/{id}/start": {
+    "/poll/{id}/start": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1470,7 +1471,7 @@
         ]
       }
     },
-    "/api/poll/{id}/end": {
+    "/poll/{id}/end": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1522,7 +1523,7 @@
         ]
       }
     },
-    "/api/comment/{id}": {
+    "/comment/{id}": {
       "get": {
         "tags": [
           "Comment - 評論"
@@ -1697,7 +1698,7 @@
         ]
       }
     },
-    "/api/comment/": {
+    "/comment/": {
       "post": {
         "tags": [
           "Comment - 評論"
@@ -1761,7 +1762,7 @@
         ]
       }
     },
-    "/api/option/vote": {
+    "/option/vote": {
       "post": {
         "tags": [
           "Option - 投票及投票選項"
@@ -1988,7 +1989,7 @@
         ]
       }
     },
-    "/api/option/": {
+    "/option/": {
       "post": {
         "tags": [
           "Option - 投票及投票選項"
@@ -2141,7 +2142,7 @@
         ]
       }
     },
-    "/api/option/{id}": {
+    "/option/{id}": {
       "delete": {
         "tags": [
           "Option - 投票及投票選項"
@@ -2600,6 +2601,10 @@
           "type": "array",
           "example": [],
           "items": {}
+        },
+        "status": {
+          "type": "string",
+          "example": "active"
         }
       }
     },

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -17,18 +17,26 @@ app.use(morgan('dev'));
 
 app.use(swaggerRouter);
 app.use(
-  '/',
+  '/api',
   verifyMiddleware(
     [
-      { path: '/api/auth/login', method: 'POST' },
-      { path: '/api/auth/register', method: 'POST' },
-      { path: '/api/auth/reset-password', method: 'PUT' },
-      { path: '/api/auth/verify', method: 'GET' },
-      { path: '/api/auth/verify', method: 'POST' },
-      { path: '/api/member/', method: 'GET' },
-      { path: '/api/comment/', method: 'GET' },
-      { path: '/api/option/', method: 'GET' },
-      { path: '/api/poll/', method: 'GET' },
+      { path: '/auth/login', method: 'POST' },
+      { path: '/auth/register', method: 'POST' },
+      { path: '/auth/reset-password', method: 'PUT' },
+      { path: '/auth/verify', method: 'GET' },
+      { path: '/auth/verify', method: 'POST' },
+      { path: '/auth/google', method: 'GET' },
+      { path: '/auth/google/callback', method: 'GET' },
+      { path: '/auth/facebook', method: 'GET' },
+      { path: '/auth/facebook/callback', method: 'GET' },
+      { path: '/auth/line', method: 'GET' },
+      { path: '/auth/line/callback', method: 'GET' },
+      { path: '/auth/discord', method: 'GET' },
+      { path: '/auth/discord/callback', method: 'GET' },
+      { path: '/member/', method: 'GET' },
+      { path: '/comment/', method: 'GET' },
+      { path: '/option/', method: 'GET' },
+      { path: '/poll/', method: 'GET' },
   ]),
   Routes,
 );

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -8,6 +8,7 @@ authRouter.post(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '註冊'
+   * #swagger.path = '/api/auth/register'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -63,6 +64,7 @@ authRouter.post(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '登入'
+   * #swagger.path = '/api/auth/login'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -112,6 +114,7 @@ authRouter.get(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '登出'
+   * #swagger.path = '/api/auth/logout'
    * #swagger.responses[200] = {
     schema: {
       status: true,
@@ -139,6 +142,7 @@ authRouter.get(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '由 Token 取得使用者資訊'
+   * #swagger.path = '/api/auth/check'
    * #swagger.responses[200] = {
     schema: {
       status: true,
@@ -166,6 +170,7 @@ authRouter.post(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '重設密碼'
+   * #swagger.path = '/api/auth/reset-password'
    * #swagger.parameters['body'] = {
     in: 'body',
     required: true,
@@ -200,6 +205,7 @@ authRouter.post(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '更新帳號密碼'
+   * #swagger.path = '/api/auth/change-password'
    * #swagger.parameters['body'] = {
     in: 'body',
     required: true,
@@ -249,6 +255,7 @@ authRouter.put(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '重設密碼'
+   * #swagger.path = '/api/auth/reset-password'
    * #swagger.parameters['body'] = {
     in: 'body',
     required: true,
@@ -297,6 +304,7 @@ authRouter.get(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '驗證帳號'
+   * #swagger.path = '/api/auth/verify'
    * #swagger.parameters['parameterName'] = {
     in: 'query',
     type: 'string',
@@ -339,6 +347,7 @@ authRouter.post(
   /**
    * #swagger.tags = ['Auth - 認證']
    * #swagger.description = '重新發送驗證 Email'
+   * #swagger.path = '/api/auth/verify'
    * #swagger.parameters['body'] = {
       email: 'example@example.com',
     }

--- a/src/routes/comment.router.ts
+++ b/src/routes/comment.router.ts
@@ -8,6 +8,7 @@ commentRouter.get(
   /**
    * #swagger.tags = ['Comment - 評論']
    * #swagger.description = '獲取評論'
+   * #swagger.path = '/api/comment/{id}'
    * #swagger.parameters['id'] = {
   in: 'path',
   required: true,
@@ -35,6 +36,7 @@ commentRouter.post(
   /**
    * #swagger.tags = ['Comment - 評論']
    * #swagger.description = '新增評論'
+   * #swagger.path = '/api/comment/'
    *  #swagger.parameters['body'] = {
   in: 'body',
   required: true,
@@ -68,6 +70,7 @@ commentRouter.put(
   /**
    * #swagger.tags = ['Comment - 評論']
    * #swagger.description = '更新評論'
+   * #swagger.path = '/api/comment/{id}'
   * #swagger.parameters['id'] = {
   in: 'path',
   required: true,
@@ -116,6 +119,7 @@ commentRouter.delete(
   /**
    * #swagger.tags = ['Comment - 評論']
    * #swagger.description = '刪除評論'
+   * #swagger.path = '/api/comment/{id}'
    *  #swagger.parameters['id'] = {
   in: 'path',
   required: true,

--- a/src/routes/imgur.router.ts
+++ b/src/routes/imgur.router.ts
@@ -9,6 +9,7 @@ imgurRouter.post(
   /**
    * #swagger.tags = ['Imgur - 圖片']
    * #swagger.description = '上傳圖片'
+   * #swagger.path = '/api/imgur/upload'
    * #swagger.consumes = ['multipart/form-data']
    * #swagger.parameters['singleFile'] = {
             in: 'formData',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -20,11 +20,11 @@ apiRouter.use((req: Request, _, next: NextFunction) => {
   next();
 });
 
-apiRouter.use('/api/auth', authRouter);
-apiRouter.use('/api/imgur', imgurRouter);
-apiRouter.use('/api/member', memberRouter);
-apiRouter.use('/api/poll', pollRouter);
-apiRouter.use('/api/comment', commentRouter);
-apiRouter.use('/api/option', optionRouter);
+apiRouter.use('/auth', authRouter);
+apiRouter.use('/imgur', imgurRouter);
+apiRouter.use('/member', memberRouter);
+apiRouter.use('/poll', pollRouter);
+apiRouter.use('/comment', commentRouter);
+apiRouter.use('/option', optionRouter);
 
 export default apiRouter;

--- a/src/routes/member.router.ts
+++ b/src/routes/member.router.ts
@@ -9,6 +9,7 @@ memberRouter.get(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '獲取所有會員'
+   * #swagger.path = '/api/member/'
    * #swagger.parameters['page'] = {
       in: 'query',
       required: false,
@@ -40,6 +41,7 @@ memberRouter.get(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '根據 ID 獲取會員詳情'
+   * #swagger.path = '/api/member/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -66,6 +68,7 @@ memberRouter.put(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '更新會員資料'
+   * #swagger.path = '/api/member/'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -108,6 +111,7 @@ memberRouter.delete(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '刪除會員'
+   * #swagger.path = '/api/member/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -147,6 +151,7 @@ memberRouter.get(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '加入追蹤'
+   * #swagger.path = '/api/member/follow/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -185,6 +190,7 @@ memberRouter.delete(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '取消追蹤'
+   * #swagger.path = '/api/member/follow/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,

--- a/src/routes/option.router.ts
+++ b/src/routes/option.router.ts
@@ -10,6 +10,7 @@ optionRouter.post(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '投票'
+   * #swagger.path = '/api/option/vote'
     * #swagger.parameters['body'] = {
         in: 'body',
         required: true,
@@ -52,6 +53,7 @@ optionRouter.put(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '更改投票'
+   * #swagger.path = '/api/option/vote'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -100,6 +102,7 @@ optionRouter.delete(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '取消投票'
+   * #swagger.path = '/api/option/vote'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -140,6 +143,7 @@ optionRouter.post(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '新增選項'
+   * #swagger.path = '/api/option/'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -180,6 +184,7 @@ optionRouter.put(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '更新選項'
+   * #swagger.path = '/api/option/'
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
@@ -223,6 +228,7 @@ optionRouter.delete(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '刪除選項'
+   * #swagger.path = '/api/option/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,

--- a/src/routes/poll.router.ts
+++ b/src/routes/poll.router.ts
@@ -10,6 +10,7 @@ pollRouter.get(
   /**
   * #swagger.tags = ['Poll - 投票']
   * #swagger.description = '獲取所有投票'
+  * #swagger.path = '/api/poll/'
   * #swagger.parameters['page'] = {
     in: 'query',
     required: false,
@@ -26,9 +27,11 @@ pollRouter.get(
     schema: {
       status: true,
       message: "獲取投票列表成功",
-      result: {
-        $ref: "#/definitions/Poll"
-      },
+      result: [
+        {
+          $ref: "#/definitions/Poll"
+        },
+      ],
     },
     description: "獲取投票列表成功"
   }
@@ -41,6 +44,7 @@ pollRouter.get(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '根據 ID 獲取投票詳情'
+   * #swagger.path = '/api/poll/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -70,6 +74,7 @@ pollRouter.post(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '創建新投票'
+   * #swagger.path = '/api/poll/'
    * #swagger.parameters['body'] = {
     in: 'body',
     required: true,
@@ -107,6 +112,7 @@ pollRouter.put(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '更新投票'
+   * #swagger.path = '/api/poll/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -157,6 +163,7 @@ pollRouter.delete(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '刪除投票'
+   * #swagger.path = '/api/poll/{id}'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -184,10 +191,11 @@ pollRouter.delete(
   handleErrorAsync(PollController.deletePoll),
 );
 
-pollRouter.post(
+pollRouter.get(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '投票按讚'
+   * #swagger.path = '/api/poll/{id}/like'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -222,6 +230,7 @@ pollRouter.delete(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '取消投票按讚'
+   * #swagger.path = '/api/poll/{id}/like'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -248,7 +257,7 @@ pollRouter.delete(
     "Bearer": []
     }]
    */
-  '/:id/unlike',
+  '/:id/like',
   handleErrorAsync(PollController.unlikePoll),
 );
 
@@ -257,6 +266,7 @@ pollRouter.get(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '投票開始'
+   * #swagger.path = '/api/poll/{id}/start'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -292,6 +302,7 @@ pollRouter.get(
   /**
    * #swagger.tags = ['Poll - 投票']
    * #swagger.description = '投票結束'
+   * #swagger.path = '/api/poll/{id}/end'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,


### PR DESCRIPTION
文件：重構 API 路由及文檔

- 更新 API Fetch 範例，改用包含 `baseUrl` 的模板字面量
- 在 `swagger.ts` 的 `PollCreate` 物件中新增帶有字串 `"active"` 的 `status` 欄位
- 將各路由中的 API 路徑前綴從 `/api/` 修改為基礎路徑於 `swagger_output.json`
- 使用新的回應格式與端點調整來更新 `swagger_output.json`
- 在 `index.ts` 調整路由前綴從 `'/'` 改為 `'/api'`，並從各個路由中移除 `/api/` 前綴
- 在 `auth.router.ts` 中新增 Google、Facebook、LINE 與 Discord 的 OAuth 路由文檔
- 更新 Swagger 註解中跨多個路由器檔案（例如：`auth.router.ts`、`comment.router.ts`、`imgur.router.ts` 等）的各路徑資訊
- 對於在 `poll.router.ts` 為投票按讚的行為，將 HTTP 動詞從 POST 改為 GET

請記得翻譯給定的 git 提交訊息所有內容。