### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -566,9 +566,18 @@
         "parameters": [
           {
             "name": "body",
-            "email": "example@example.com",
-            "in": "query",
-            "type": "string"
+            "in": "body",
+            "required": true,
+            "description": "重新發送驗證 Email",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "example": "example@example.com"
+                }
+              }
+            }
           }
         ],
         "responses": {
@@ -604,7 +613,7 @@
         }
       }
     },
-    "/imgur/upload": {
+    "/api/imgur/upload": {
       "post": {
         "tags": [
           "Imgur - 圖片"
@@ -1046,7 +1055,7 @@
         ]
       }
     },
-    "/poll/": {
+    "/api/poll/": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1149,7 +1158,7 @@
         ]
       }
     },
-    "/poll/{id}": {
+    "/api/poll/{id}": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1317,7 +1326,7 @@
         ]
       }
     },
-    "/poll/{id}/like": {
+    "/api/poll/{id}/like": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1419,7 +1428,7 @@
         ]
       }
     },
-    "/poll/{id}/start": {
+    "/api/poll/{id}/start": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1471,7 +1480,7 @@
         ]
       }
     },
-    "/poll/{id}/end": {
+    "/api/poll/{id}/end": {
       "get": {
         "tags": [
           "Poll - 投票"
@@ -1523,7 +1532,7 @@
         ]
       }
     },
-    "/comment/{id}": {
+    "/api/comment/{id}": {
       "get": {
         "tags": [
           "Comment - 評論"
@@ -1698,7 +1707,7 @@
         ]
       }
     },
-    "/comment/": {
+    "/api/comment/": {
       "post": {
         "tags": [
           "Comment - 評論"
@@ -1762,7 +1771,7 @@
         ]
       }
     },
-    "/option/vote": {
+    "/api/option/vote": {
       "post": {
         "tags": [
           "Option - 投票及投票選項"
@@ -1989,7 +1998,7 @@
         ]
       }
     },
-    "/option/": {
+    "/api/option/": {
       "post": {
         "tags": [
           "Option - 投票及投票選項"
@@ -2142,7 +2151,7 @@
         ]
       }
     },
-    "/option/{id}": {
+    "/api/option/{id}": {
       "delete": {
         "tags": [
           "Option - 投票及投票選項"

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -24,7 +24,7 @@ class AuthController {
     if (!decoded) {
       throw appError({ code: 400, message: "無效的 token", next });
     }
-    const user = await User.findOne({ verificationToken: token });
+    const user = await User.findOne({ verificationToken: token }).exec();
 
     if (!user) {
       throw appError({ code: 404, message: "無效的驗證連結或已過期", next });
@@ -152,7 +152,7 @@ class AuthController {
     if (!user) {
       throw appError({ code: 404, message: "無效的重設連結或已過期", next });
     }
-    await User.findByIdAndUpdate(user._id, { resetToken: "", password });
+    await User.findByIdAndUpdate(user._id, { resetToken: "", password }).exec();
     return successHandle(_res, "成功重設密碼", { result: true });
   };
 

--- a/src/controllers/thirdPartyAuth.controller.ts
+++ b/src/controllers/thirdPartyAuth.controller.ts
@@ -43,7 +43,7 @@ class ThirdPartyAuthController {
     return field
       ? User.findOne({
           $or: [{ [field]: id }, { email }],
-        }).exec()
+        })
       : null;
   }
 

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -48,18 +48,23 @@ const pollSchema = new Schema<IPoll>({
   },
   options: [
     {
+      _id: false,
       type: Schema.Types.ObjectId,
       ref: 'Option',
     },
   ],
   like: [
     {
-      type: Schema.Types.ObjectId,
-      ref: 'User',
+      _id: false,
+      user: {
+        type: Schema.Types.ObjectId,
+        ref: 'User',
+      },
     },
   ],
   comments: [
     {
+      _id: false,
       type: Schema.Types.ObjectId,
       ref: 'Comment',
     },

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -119,6 +119,15 @@ const userSchema = new Schema<IUser>(
       type: String,
       select: false,
     },
+    likedPolls: [
+      {
+        _id: false,
+        poll: {
+          type: Schema.Types.ObjectId,
+          ref: 'Poll',
+        },
+      },
+    ],
   },
   {
     versionKey: false,
@@ -147,7 +156,7 @@ userSchema.pre(/^find/, function (next) {
   (this as IUser).populate({
     path: 'following.user followers.user',
     select: '-createdAt -following -isValidator -followers',
-  });
+    });
   next();
 });
 

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -349,8 +349,14 @@ authRouter.post(
    * #swagger.description = '重新發送驗證 Email'
    * #swagger.path = '/api/auth/verify'
    * #swagger.parameters['body'] = {
+    in: 'body',
+    required: true,
+    type: 'object',
+    description: '重新發送驗證 Email',
+    schema: {
       email: 'example@example.com',
     }
+  }
    * #swagger.responses[200] = {
     schema: {
       status: true,

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -142,7 +142,7 @@ export class AuthService {
 
   static updatePassword = async ({ email, password, next }: { email: string; password: string; next: NextFunction }) => {
     try {
-      const user = await User.findOne({ email });
+      const user = await User.findOne({ email }).exec();
       if (!user) {
         throw appError({ code: 404, message: '此 Email 未註冊', next });
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,7 @@ export interface IUser extends Document {
   facebookId?: string;
   lineId?: string;
   discordId?: string;
+  likedPolls: IPoll['_id'][];
 }
 
 export interface CreateUserRequest {
@@ -61,7 +62,7 @@ export interface IPoll extends Document {
   isPrivate: boolean;
   totalVoters: number;
   like: {
-    userId: IUser['_id'];
+    user: IUser['_id'];
   }[];
   comments: {
     commentId: IComment['_id'];


### PR DESCRIPTION
功能新增：重構 API 端點和數據模式

- 更新 `swagger_output.json` 文件，更改 API 端點的參數以在消息體模式中期望包含電子郵件。
- 在多個 API 端點前加上 `/api` 前綴，更新它們的路徑。
- 修改 AuthController，新增 `.exec()` 使Mongoose查詢針對用戶操作更有效率。
- 在 MemberController 中，從用戶投影中移除 `likedPolls` 字段，調整查詢連鎖，為 getMemberById 增加 lean 與 populate 方法，並移除 `.exec()` 方法。
- 在 PollController 中，引入 User 模型，明確定義投票模式中的 `_id` 字段，更新方法以使用 `.exec()`，並修改喜歡與不喜歡投票功能以更新用戶的喜歡投票列表。
- 在用戶模型模式中引入 `likedPolls` 數組以跟踪喜歡的投票。
- 調整 `auth.router.ts` 以更明確地為重新發送驗證電子郵件的端點提供消息體參數。
- 在 AuthService 中更新查詢，必要時增加 `.exec()`。
- 在 `index.ts` 中修訂類型，以反映用戶和投票介面中的 `likedPolls` 引用。