### PR TITLE
GIT 提交信息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -1599,10 +1599,6 @@
             "schema": {
               "type": "object",
               "properties": {
-                "commentId": {
-                  "type": "string",
-                  "example": "60f3e3e3e3e3e3e3e3e3e3e3"
-                },
                 "content": {
                   "type": "string",
                   "example": "這是一則更新後的評論"

--- a/src/controllers/poll.controller.ts
+++ b/src/controllers/poll.controller.ts
@@ -69,8 +69,9 @@ class PollController {
 
   // 根據 ID 獲取投票詳情
   public static getPollById: RequestHandler = async (req, res: Response, next) => {
-      const { pollId } = req.params;
-      const poll = await Poll.findById(pollId)
+    const { id } = req.params;
+    console.log('pollId: ', id);
+      const poll = await Poll.findById(id)
         .populate('options')
         .populate('createdBy')
         .populate('comments')
@@ -120,7 +121,7 @@ class PollController {
       .populate('options')
       .populate({
         path: 'comments',
-        populate: { path: 'userId', select: 'name avatar' }
+        populate: { path: 'user', select: 'name avatar' }
       })
       .exec();
 

--- a/src/models/comment.ts
+++ b/src/models/comment.ts
@@ -7,7 +7,7 @@ const commentSchema = new Schema<IComment>({
     ref: 'Poll',
     required: [true, '請確實填寫投票'],
   },
-  userId: {
+  author: {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: [true, '請確實填寫留言者'],
@@ -21,10 +21,6 @@ const commentSchema = new Schema<IComment>({
   createdTime: {
     type: Date,
     default: Date.now,
-  },
-  role: {
-    type: String,
-    default: 'user',
   },
   edited: {
     type: Boolean,
@@ -46,7 +42,7 @@ const commentSchema = new Schema<IComment>({
 
 commentSchema.pre(/^find/, function(next) {
   (this as IComment).populate([{
-    path: 'userId',
+    path: 'author',
     select: 'name avatar'
   },{
     path: 'pollId',

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -65,8 +65,10 @@ const pollSchema = new Schema<IPoll>({
   comments: [
     {
       _id: false,
-      type: Schema.Types.ObjectId,
-      ref: 'Comment',
+      comment: {
+        type: Schema.Types.ObjectId,
+        ref: 'Comment',
+      },
     },
   ],
   status: {

--- a/src/routes/comment.router.ts
+++ b/src/routes/comment.router.ts
@@ -83,7 +83,6 @@ commentRouter.put(
   type: 'object',
   description: '更新評論',
   schema: {
-    commentId: '60f3e3e3e3e3e3e3e3e3e3e3',
     content: '這是一則更新後的評論'
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,7 +65,7 @@ export interface IPoll extends Document {
     user: IUser['_id'];
   }[];
   comments: {
-    commentId: IComment['_id'];
+    comment: IComment['_id'];
   }[];
   options: {
     optionId: IOption['_id'];
@@ -103,11 +103,10 @@ export interface CreateOptionRequest {
 
 export interface IComment extends Document {
   _id?: string;
-  userId: IUser['_id'];
+  author: IUser['_id'];
   pollId: IPoll['_id'];
   content: string;
   createdTime: Date;
-  role: 'author' | 'user';
   edited: boolean;
   updateTime: Date;
 }


### PR DESCRIPTION
重構：重構評論與投票關聯

- 從 Swagger 輸出和驗證架構中移除 `commentId` 屬性，這表示 `commentId` 很可能來自不同的來源或者已經不再需要了。
- 在 `comment.controller.ts` 中同時導入 `Poll` 模型和 `Comment`，並修改建立與刪除評論方法以與相關的投票文檔互動。
- 將 `Comment` 模型中的 `userId` 引用改為 `author`，並移除 `role` 欄位，暗示對評論作者處理方式的轉變。
- 修改 `Poll` 模型，將 `comment` 對象嵌套在 `comments` 陣列中。
- 更新投票控制器中的 `getPollById` 和 `updatePoll` 函數，以適應評論引用方式的變更，以及記錄投票 ID。
- 調整 `comment.router.ts`，由於評論結構更新，移除 Swagger 文件中對 `commentId` 的直接引用。
- 更新 `types/index.ts` 中的類型定義以符合評論和投票數據結構的變化。