### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -2068,13 +2068,22 @@
             "Bearer": []
           }
         ]
-      },
+      }
+    },
+    "/api/option/{id}": {
       "put": {
         "tags": [
           "Option - 投票及投票選項"
         ],
         "description": "更新選項",
         "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "選項ID"
+          },
           {
             "name": "body",
             "in": "body",
@@ -2083,10 +2092,6 @@
             "schema": {
               "type": "object",
               "properties": {
-                "optionId": {
-                  "type": "string",
-                  "example": "60f3e3e3e3e3e3e3e3e3e3e3"
-                },
                 "updateData": {
                   "type": "object",
                   "properties": {
@@ -2145,9 +2150,7 @@
             "Bearer": []
           }
         ]
-      }
-    },
-    "/api/option/{id}": {
+      },
       "delete": {
         "tags": [
           "Option - 投票及投票選項"

--- a/src/controllers/option.controller.ts
+++ b/src/controllers/option.controller.ts
@@ -104,13 +104,15 @@ class OptionController {
   };
 
   // 更新選項
-  public static updateOption: RequestHandler = async (req, res, next ) => {
-      const { optionId, updateData } = req.body;
+  public static updateOption: RequestHandler = async (req, res, next) =>
+  {
+    const { id } = req.params;
+      const { updateData } = req.body;
       const validatorInput = await optionSchema.validate(updateData);
       if (!validatorInput) {
         throw appError({ code: 400, message: '請確實填寫選項資訊', next });
       }
-      const updatedOption = await Option.findByIdAndUpdate(optionId, validatorInput, { new: true });
+      const updatedOption = await Option.findByIdAndUpdate(id, validatorInput, { new: true });
       if (!updatedOption) {
         throw appError({ code: 404, message: '找不到選項', next });
       }

--- a/src/routes/option.router.ts
+++ b/src/routes/option.router.ts
@@ -184,14 +184,19 @@ optionRouter.put(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '更新選項'
-   * #swagger.path = '/api/option/'
+   * #swagger.path = '/api/option/{id}'
+   * #swagger.parameters['id'] = {
+    in: 'path',
+    required: true,
+    type: 'string',
+    description: '選項ID'
+    }
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
       type: 'object',
       description: '更新選項',
       schema: {
-        optionId: '60f3e3e3e3e3e3e3e3e3e3e3',
         updateData: {
         title: 'Vue',
         imageUrl: 'https://imgur.com/TECsq2J.png',
@@ -220,7 +225,7 @@ optionRouter.put(
         "Bearer": []
       }]
    */
-  '/',
+  '/:id',
   handleErrorAsync(OptionController.updateOption),
 );
 


### PR DESCRIPTION
功能：重構選項更新 API 端點

- 新增用於通過 ID 更新一個選項的 API 端點至 Swagger 文件中。
- 從 Swagger 文件和更新選項的端點移除 `optionId` 參數，改用路徑參數。
- 更新 Option 控制器中的 `updateOption` 方法，使用來自 `req.params` 的 `id` 替代來自 `req.body` 的 `optionId`。
- 更新 `option.router.ts` 中的路由，使用 `id` 路徑參數來更新選項。