### PR TITLE
GIT 提交訊息:

### DIFF
--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -112,6 +112,13 @@ const doc = {
         },
       ],
       id: "62e348927278654321000001",
+      likedPolls: [
+        {
+          _id: "62e348927278654321000001",
+          title: "最喜歡的程式語言",
+          imageUrl: "https://i.imgur.com/D3hp8H6.png",
+        },
+      ],
     },
     Members: [
       {

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -903,7 +903,7 @@
         ]
       }
     },
-    "/api/member/follow/{id}": {
+    "/api/member/{id}/follow": {
       "get": {
         "tags": [
           "Member - 會員"
@@ -2432,6 +2432,26 @@
         "id": {
           "type": "string",
           "example": "62e348927278654321000001"
+        },
+        "likedPolls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "type": "string",
+                "example": "62e348927278654321000001"
+              },
+              "title": {
+                "type": "string",
+                "example": "最喜歡的程式語言"
+              },
+              "imageUrl": {
+                "type": "string",
+                "example": "https://i.imgur.com/D3hp8H6.png"
+              }
+            }
+          }
         }
       }
     },

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -3,7 +3,7 @@ import { User } from "@/models";
 import { appError, successHandle } from "@/utils";
 import validator from "validator";
 import { AuthService } from "@/services";
-import { IUser } from '../types/index';
+import { IUser } from "../types/index";
 
 class MemberController {
   public static getAllMembers: RequestHandler = async (req, res) => {
@@ -20,9 +20,7 @@ class MemberController {
         "-gender -coin -followers -following -socialMedia -updatedAt -isValidator -isSubscribed -likedPolls"
       )
       .skip((page - 1) * limit)
-      .limit(limit)
-      ;
-
+      .limit(limit);
     // 計算總頁數
     const totalPages = Math.ceil(totalCount / limit);
 
@@ -35,10 +33,9 @@ class MemberController {
   public static getMemberById: RequestHandler = async (req, res, next) => {
     const { id } = req.params;
     const user = await User.findById(id)
-    .select('-coin -updatedAt -isValidator')
-    .lean()
-    .populate('likedPolls', { title: 1, imageUrl: 1, description: 1, totalVoters: 1, createdBy: 0, options: 0, like: 0, comments: 0 })
-    ;
+      .select("-coin -updatedAt -isValidator")
+      .populate("likedPolls", { title: 1, _id: 1 })
+      .lean();
     if (!user)
       throw appError({
         code: 404,
@@ -66,8 +63,10 @@ class MemberController {
     if (updateData["avatar"] && !validator.isURL(updateData["avatar"])) {
       throw appError({ code: 400, message: "請確認照片是否傳入網址", next });
     }
-    const userData = await User.findByIdAndUpdate(user.id, updateData, { new: true, runValidators: true }).select('-coin -updatedAt -isValidator -isSubscribed')
-    ;
+    const userData = await User.findByIdAndUpdate(user.id, updateData, {
+      new: true,
+      runValidators: true,
+    }).select("-coin -updatedAt -isValidator -isSubscribed");
     return successHandle(res, "成功更新使用者資訊！", { result: userData });
   };
 
@@ -76,78 +75,73 @@ class MemberController {
       params: { id: targetID },
     } = req;
     const { id } = req.user as IUser;
+
     if (!targetID)
       throw appError({ code: 400, message: "請提供使用者 id", next });
-    if (targetID === id) {
+    if (targetID === id)
       throw appError({ code: 401, message: "您無法追蹤自己", next });
-    }
 
-    // 檢查是否已追蹤該使用者
-    const existingFollower = await User.findOne({
-      id,
-      "following.user": targetID,
-    }).exec();
-    if (existingFollower) {
+    const user = await User.findById(id);
+    if (!user) throw appError({ code: 404, message: "找不到使用者", next });
+    const isAlreadyFollowing =
+      user.following &&
+      user.following.some(
+        (following) => following.user._id.toString() === targetID
+      );
+    if (isAlreadyFollowing)
       throw appError({ code: 400, message: "您已經追蹤了該使用者", next });
-    }
 
     const resultUserData = await User.findOneAndUpdate(
-      { id, "following.user": { $ne: targetID } },
+      { _id: id, "following.user": { $ne: targetID } },
       { $addToSet: { following: { user: targetID } } },
       { new: true }
-    ).select('-coin -updatedAt -isValidator -isSubscribed');
+    ).select("-coin -updatedAt -isValidator -isSubscribed");
 
     await User.findOneAndUpdate(
-      { _id: targetID, "followers.user": { $ne: id } },
+      { _id: targetID },
       { $addToSet: { followers: { user: id } } }
     );
 
-    return successHandle(res, "您已成功追蹤！", { result: resultUserData });
+    successHandle(res, "您已成功追蹤！", { result: resultUserData });
   };
 
-  public static deleteFollower: RequestHandler = async (
-    req,
-    res,
-    next
-  ) => {
+  public static deleteFollower: RequestHandler = async (req, res, next) => {
     const {
       params: { id: targetID },
     } = req;
     const { id } = req.user as IUser;
+
     if (!targetID)
       throw appError({ code: 400, message: "請提供使用者 id", next });
-    if (targetID === id) {
+    if (targetID === id)
       throw appError({ code: 401, message: "您無法取消追蹤自己", next });
-    }
 
-    // 檢查是否已追蹤該使用者
-    const existingFollowing = await User.findOne({
-      id,
-      "following.user": targetID,
-    });
-    if (!existingFollowing) {
+    const user = await User.findById(id);
+    if (!user) throw appError({ code: 404, message: "找不到使用者", next });
+    console.log(user.following);
+    const isFollowing =
+      user.following &&
+      user.following.some(
+        (following) => following.user._id.toString() === targetID
+      );
+    if (!isFollowing)
       throw appError({
         code: 400,
         message: "您尚未追蹤該使用者，無法取消追蹤",
         next,
       });
-    }
 
-    const resultUserData = await User.findByIdAndUpdate(
-      id,
-      {
-        $pull: { following: { user: targetID } },
-      },
-      { new: true }
-    ).select('-coin -updatedAt -isValidator -isSubscribed');
+    await User.findOneAndUpdate(
+      { _id: id },
+      { $pull: { following: { user: targetID } } }
+    );
 
-    await User.findByIdAndUpdate(targetID, {
-      $pull: { followers: { user: id } },
-    });
+    await User.findOneAndUpdate(
+      { _id: targetID },
+      { $pull: { followers: { user: id } } }
+    );
 
-    return successHandle(res, "您已成功取消追蹤！", {
-      result: resultUserData,
-    });
+    successHandle(res, "取消追踪成功", {});
   };
 }
 

--- a/src/routes/member.router.ts
+++ b/src/routes/member.router.ts
@@ -151,7 +151,7 @@ memberRouter.get(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '加入追蹤'
-   * #swagger.path = '/api/member/follow/{id}'
+   * #swagger.path = '/api/member/{id}/follow'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -185,12 +185,12 @@ memberRouter.get(
       "Bearer": []
     }]
     */
-  '/follow/:id',  handleErrorAsync(MemberController.addFollower));
+  '/:id/follow',  handleErrorAsync(MemberController.addFollower));
 memberRouter.delete(
   /**
    * #swagger.tags = ['Member - 會員']
    * #swagger.description = '取消追蹤'
-   * #swagger.path = '/api/member/follow/{id}'
+   * #swagger.path = '/api/member/{id}/follow'
    * #swagger.parameters['id'] = {
     in: 'path',
     required: true,
@@ -224,6 +224,6 @@ memberRouter.delete(
       "Bearer": []
     }]
     */
-  '/follow/:id',  handleErrorAsync(MemberController.deleteFollower));
+  '/:id/follow',  handleErrorAsync(MemberController.deleteFollower));
 
 export default memberRouter;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,11 +15,11 @@ export interface IUser extends Document {
     },
   ];
   followers?: {
-    userId: IUser['_id'];
+    user: IUser['_id'];
     createdAt: Date;
   }[];
   following?: {
-    userId: IUser['_id'];
+    user: IUser['_id'];
     createdAt: Date;
   }[];
   isValidator: boolean;


### PR DESCRIPTION
重構：重構會員 API 及文件說明

- 在 swagger 文件的用戶對象中新增一個名為 `likedPolls` 的屬性，並附一個範例投票對象
- 在 swagger 文件中將端點路徑從 `/api/member/follow/{id}` 調整至 `/api/member/{id}/follow`
- 統一字串引號的使用，將 `member.controller.ts` 中的單引號換為雙引號
- 精簡 `member.controller.ts` 中的代碼，移除不必要的換行字元
- 優化 `member.controller.ts` 中的 `likedPolls` 生成，僅包括 `_id` 和 `title`
- 簡化 `member.controller.ts` 中的 `addFollower` 和 `deleteFollower` 方法
- 調整 `member.router.ts` 中的追蹤/取消追蹤端點路徑，以符合修改後的 swagger 文件
- 在 `types/index.ts` 的 `IUser` 介面中進行精煉，將 `followers` 和 `following` 數組中的 `userId` 重命名為 `user`
- 移除 `member.controller.ts` deleteFollower 方法中不必要的日誌記錄
- 確保 `member.controller.ts` 的 addFollower 和 deleteFollower 方法在找不到用戶時進行適當的錯誤處理