### PR TITLE
GIT 提交訊息：

### DIFF
--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -34,8 +34,11 @@ class MemberController {
     const { id } = req.params;
     const user = await User.findById(id)
       .select("-coin -updatedAt -isValidator")
-      .populate("likedPolls", { title: 1, _id: 1 })
-      .lean();
+      .populate({
+        path: 'likedPolls.poll',
+        select: {createdBy: 0, like: 0, comments: 0, options: 0, isPrivate: 0, createdTime: 0, createdAt: 0, updatedAt: 0}
+      })
+      .exec();
     if (!user)
       throw appError({
         code: 404,

--- a/src/controllers/option.controller.ts
+++ b/src/controllers/option.controller.ts
@@ -1,134 +1,198 @@
-import { RequestHandler } from 'express';
-import { Poll, Option } from '@/models';
-import { appError, successHandle } from '@/utils';
-import { IUser } from '@/types';
-import { array, object, string } from 'yup';
+import { RequestHandler } from "express";
+import { Poll, Option, User } from "@/models";
+import { appError, successHandle } from "@/utils";
+import { IUser } from "@/types";
+import { array, object, string } from "yup";
 
-const optionArraySchema = array(object({
-  title: string().required('請填寫選項名稱').min(1, '選項名稱請大於 1 個字').max(50, '選項名稱長度過長，最多只能 50 個字'),
-  imageUrl: string().default('https://imgur.com/TECsq2J.png'),
-}));
+const optionArraySchema = array(
+  object({
+    title: string()
+      .required("請填寫選項名稱")
+      .min(1, "選項名稱請大於 1 個字")
+      .max(50, "選項名稱長度過長，最多只能 50 個字"),
+    imageUrl: string().default("https://imgur.com/TECsq2J.png"),
+  })
+);
 
 const optionSchema = object({
-  title: string().required('請填寫選項名稱').min(1, '選項名稱請大於 1 個字').max(50, '選項名稱長度過長，最多只能 50 個字'),
-  imageUrl: string().default('https://imgur.com/TECsq2J.png'),
+  title: string()
+    .required("請填寫選項名稱")
+    .min(1, "選項名稱請大於 1 個字")
+    .max(50, "選項名稱長度過長，最多只能 50 個字"),
+  imageUrl: string().default("https://imgur.com/TECsq2J.png"),
 });
 class OptionController {
   // 投票
-  public static vote: RequestHandler = async (req, res, next ) => {
-      const { optionId } = req.body;
-      const { id } = req.user as IUser;
+  public static vote: RequestHandler = async (req, res, next) => {
+    const { optionId } = req.body;
+    const { id } = req.user as IUser;
+    const poll = await Poll.findOne({ options: optionId });
+    const option = await Option.findById(optionId);
+    const user = await User.findOne({ _id: id });
 
-      // 檢查是否已經投過票
-      const option = await Option.findById(optionId);
-      if (!option) {
-        throw appError({ code: 404, message: '找不到選項', next });
-      }
-      if (option?.voters.find((voter) => voter && voter.userId && voter.userId === id)) {
-        throw appError({ code: 400, message: '您已經對此選項投過票', next });
-      }
-      // 添加投票者
-      option.voters.push({ userId: id, createdTime: new Date() });
-      Poll.updateOne({ options: optionId }, { $inc: { totalVoters: 1 } });
-      const updatedOption = await option.save();
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "active") {
+      throw appError({ code: 400, message: "投票未開始或是已結束", next });
+    }
+    // 檢查是否已經投過票
+    if (!option) {
+      throw appError({ code: 404, message: "找不到選項", next });
+    }
+    if (option?.voters.some((voter) => voter.user.toString() === id)) {
+      throw appError({ code: 400, message: "您已經對此選項投過票", next });
+    }
 
-      successHandle(res, '投票成功', { updatedOption });
+    // 添加投票者
+    const updatedOption = await Option.findByIdAndUpdate(
+      optionId,
+      { $push: { voters: { user, createdTime: new Date() } } },
+      { new: true }
+    )
+      .populate("voters.user", "name avatar")
+      .exec();
+
+    successHandle(res, "投票成功", { updatedOption });
   };
 
   // 更改投票
-  public static updateVote: RequestHandler = async (req, res, next ) => {
-      const { id } = req.user as IUser;
-      const { optionId, newOptionId } = req.body;
+  public static updateVote: RequestHandler = async (req, res, next) => {
+    const { id } = req.user as IUser;
+    const { id: optionId } = req.params;
+    const { newOptionId } = req.body;
 
-      // 檢查是否已經投過票
-      const option = await Option.findById(optionId);
-      if (!option) {
-        throw appError({ code: 404, message: '找不到選項', next });
-      }
-      const voter = option?.voters.find(
-        (voter) => voter && voter.userId && voter.userId === id,
-      );
-      if (!voter) {
-        throw appError({ code: 400, message: '找不到投票者', next });
-      }
+    const option = await Option.findById(optionId);
+    const user = await User.findOne({ _id: id });
+    const poll = await Poll.findOne({ options: optionId });
 
-      option.voters = option.voters.filter((voter) => voter.userId !== id);
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "active") {
+      throw appError({ code: 400, message: "投票未開始或是已結束", next });
+    }
+    // 檢查是否已經投過票
+    if (!option) {
+      throw appError({ code: 404, message: "找不到選項", next });
+    }
+    const voter = option.voters.find((voter) => voter.user.toString() === id);
+    if (!voter) {
+      throw appError({ code: 400, message: "找不到投票者", next });
+    }
 
-      const newOption = await Option.findById(newOptionId);
-      if (!newOption) {
-        throw appError({ code: 404, message: '找不到新投票選項', next });
-      }
-      newOption.voters.push({ userId: id, createdTime: new Date() });
-      await option.save();
-      const updatedNewOption = await newOption.save();
+    option.voters = option.voters.filter(
+      (voter) => voter.user.toString() !== id
+    );
 
-      successHandle(res, '更改投票成功', { updatedNewOption });
+    const newOption = await Option.findById(newOptionId);
+    if (!newOption) {
+      throw appError({ code: 404, message: "找不到新投票選項", next });
+    }
+    const updatedNewOption = await Option.findByIdAndUpdate(
+      newOptionId,
+      { $push: { voters: { user, createdTime: new Date() } } },
+      { new: true }
+    )
+      .populate("voters.user", "name avatar")
+      .exec();
+    await option.save();
+
+    successHandle(res, "更改投票成功", { updatedNewOption });
   };
 
   // 取消投票
-  public static cancelVote: RequestHandler = async (req, res, next ) => {
-      const {id} = req.user as IUser;
-      const { optionId } = req.body;
-      const option = await Option.findById(optionId);
-      if (!option) {
-        throw appError({ code: 404, message: '找不到選項', next});
-      }
-      if (!option.voters.find((voter) => voter && voter.userId && voter.userId === id)) {
-        throw appError({ code: 400, message: '您尚未對此選項投票', next});
-      }
-      // 移除投票者
-      option.voters = option.voters.filter(
-        (voter) => voter && voter.userId && voter.userId.toString() !== id,
-      );
-      await option.save();
+  public static cancelVote: RequestHandler = async (req, res, next) => {
+    const { id } = req.user as IUser;
+    const { id: optionId } = req.params;
+    const option = await Option.findById(optionId);
+    const user = await User.findById(id);
+    const poll = await Poll.findOne({ options: optionId });
 
-      // 更新 Poll 的 totalVoters
-      const poll = await Poll.findById(option.pollId);
-      if (poll) {
-        poll.totalVoters -= 1;
-        await poll.save();
-      }
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "active") {
+      throw appError({ code: 400, message: "投票未開始或是已結束", next });
+    }
+    if (!option) {
+      throw appError({ code: 404, message: "找不到選項", next });
+    }
+    console.log(option.voters);
+    if (!option.voters.find((voter) => voter.user.toString() === id)) {
+      throw appError({ code: 400, message: "您尚未對此選項投票", next });
+    }
+    // 移除投票者
+    const resultOption = await Option.findByIdAndUpdate(
+      optionId,
+      { $pull: { voters: { user } } },
+      { new: true }
+    )
+      .populate("voters.user", "name avatar")
+      .exec();
 
-      successHandle(res, '取消投票成功', {});
+    successHandle(res, "取消投票成功", { resultOption });
   };
 
   // 新增選項
-  public static createOption: RequestHandler = async (req, res, next ) => {
-      const { pollId, optionData } = req.body;
-      const validatorInput = await optionArraySchema.validate(optionData);
-      if (!validatorInput) {
-        throw appError({ code: 400, message: '請確實填寫選項資訊', next });
-      }
-      const newOption = await Option.create({ ...validatorInput, pollId });
-      successHandle(res, '新增選項成功', { newOption });
+  public static createOption: RequestHandler = async (req, res, next) => {
+    const { pollId, optionData } = req.body;
+    const poll = await Poll.findOne({ _id: pollId });
+
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "pending") {
+      throw appError({ code: 400, message: "投票已經開始或是已結束", next });
+    }
+    const validatorInput = await optionArraySchema.validate(optionData);
+    if (!validatorInput) {
+      throw appError({ code: 400, message: "請確實填寫選項資訊", next });
+    }
+    const newOption = await Option.create({ ...validatorInput, pollId });
+    successHandle(res, "新增選項成功", { newOption });
   };
 
   // 更新選項
-  public static updateOption: RequestHandler = async (req, res, next) =>
-  {
+  public static updateOption: RequestHandler = async (req, res, next) => {
     const { id } = req.params;
-      const { updateData } = req.body;
-      const validatorInput = await optionSchema.validate(updateData);
-      if (!validatorInput) {
-        throw appError({ code: 400, message: '請確實填寫選項資訊', next });
-      }
-      const updatedOption = await Option.findByIdAndUpdate(id, validatorInput, { new: true });
-      if (!updatedOption) {
-        throw appError({ code: 404, message: '找不到選項', next });
-      }
-      successHandle(res, '更新選項成功', { updatedOption });
+    const { updateData } = req.body;
+    const poll = await Poll.findOne({ options: id });
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "pending") {
+      throw appError({ code: 400, message: "投票已經開始或是已結束", next });
+    }
+    const validatorInput = await optionSchema.validate(updateData);
+    if (!validatorInput) {
+      throw appError({ code: 400, message: "請確實填寫選項資訊", next });
+    }
+    const updatedOption = await Option.findByIdAndUpdate(id, validatorInput, {
+      new: true,
+    });
+    if (!updatedOption) {
+      throw appError({ code: 404, message: "找不到選項", next });
+    }
+    successHandle(res, "更新選項成功", { updatedOption });
   };
 
   // 刪除選項
-  public static deleteOption: RequestHandler = async (req, res, next ) => {
-      const { id } = req.params;
-      const deletedOption = await Option.findByIdAndDelete(id);
-      if (!deletedOption) {
-        throw appError({ code: 404, message: '找不到選項', next });
-      }
-      successHandle(res, '刪除選項成功', { deletedOption });
+  public static deleteOption: RequestHandler = async (req, res, next) => {
+    const { id } = req.params;
+    const poll = await Poll.findOne({ options: id });
+    if (!poll) {
+      throw appError({ code: 404, message: "找不到投票", next });
+    }
+    if (poll.status !== "pending") {
+      throw appError({ code: 400, message: "投票已經開始或是已結束", next });
+    }
+    const deletedOption = await Option.findByIdAndDelete(id);
+    if (!deletedOption) {
+      throw appError({ code: 404, message: "找不到選項", next });
+    }
+    successHandle(res, "刪除選項成功", { deletedOption });
   };
-
 }
 
 export default OptionController;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -153,10 +153,16 @@ userSchema.statics.findWithoutSensitiveData = function (query) {
 };
 
 userSchema.pre(/^find/, function (next) {
-  (this as IUser).populate({
-    path: 'following.user followers.user',
-    select: '-createdAt -following -isValidator -followers',
-    });
+  (this as IUser).populate([
+    {
+    path: 'following.user',
+    select: {createdAt: 0, isValidator: 0, followers: 0, following: 0, likedPolls: 0, gender: 0, isSubscribed: 0, updatedAt: 0, coin: 0, verificationToken: 0, googleId: 0, facebookId: 0, lineId: 0, discordId: 0, }
+    },
+    {
+    path: 'followers.user',
+    select: {createdAt: 0, isValidator: 0, followers: 0, following: 0, likedPolls: 0, gender: 0, isSubscribed: 0, updatedAt: 0, coin: 0, verificationToken: 0, googleId: 0, facebookId: 0, lineId: 0, discordId: 0,}
+    },
+  ]);
   next();
 });
 

--- a/src/routes/option.router.ts
+++ b/src/routes/option.router.ts
@@ -53,14 +53,19 @@ optionRouter.put(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '更改投票'
-   * #swagger.path = '/api/option/vote'
+   * #swagger.path = '/api/option/vote/{id}'
+   * #swagger.parameters['id'] = {
+    in: 'path',
+    required: true,
+    type: 'string',
+    description: '選項ID'
+    }
    * #swagger.parameters['body'] = {
       in: 'body',
       required: true,
       type: 'object',
       description: '更改投票',
       schema: {
-          optionId: '60f3e3e3e3e3e3e3e3e3e3e3',
           newOptionId: '54f3e3e3e3e3e3e3e3e3e3e3',
       },
     }
@@ -94,7 +99,7 @@ optionRouter.put(
         "Bearer": []
       }]
    */
-  '/vote',
+  '/vote/:id',
   handleErrorAsync(OptionController.updateVote),
 );
 
@@ -102,18 +107,12 @@ optionRouter.delete(
   /**
    * #swagger.tags = ['Option - 投票及投票選項']
    * #swagger.description = '取消投票'
-   * #swagger.path = '/api/option/vote'
-   * #swagger.parameters['body'] = {
-      in: 'body',
-      required: true,
-      type: 'object',
-      description: '取消投票',
-      schema: {
-        properties: {
-          optionId: { type: 'string' },
-          userId: { type: 'string' },
-        },
-      },
+   * #swagger.path = '/api/option/vote/{id}'
+   * #swagger.parameters['id'] = {
+    in: 'path',
+    required: true,
+    type: 'string',
+    description: '選項ID'
     }
     * #swagger.responses[200] = {
         schema: {
@@ -136,7 +135,7 @@ optionRouter.delete(
         "Bearer": []
       }]
    */
-  '/vote',
+  '/vote/:id',
   handleErrorAsync(OptionController.cancelVote),
 );
 optionRouter.post(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,7 +89,7 @@ export interface IOption extends Document {
   imageUrl: string;
   pollId: IPoll['_id'];
   voters: {
-    userId: IUser['_id'];
+    user: IUser['_id'];
     createdTime: Date;
   }[];
   isWinner: boolean;


### PR DESCRIPTION
feat: 重構投票邏輯和模型關聯

- 修改 member.controller.ts 以改變 `likedPolls` 的填充條件，並將 `.lean()` 替換為 `.exec()`。
- 在 option.controller.ts 中：
  - 在投票、更新票數、取消投票、創建選項、更新選項以及刪除選項前增加檢查投票存在與狀態的條件。
  - 重構 vote、updateVote 和 cancelVote 函數以包含其他檢查，並使用 `findByIdAndUpdate` 來處理與票數相關的更改。
  - 整理代碼格式並將導入語句由單引號更改為雙引號。
- 更新 option.ts 模型，以 `user` 替代 `userId` 作為 `voters` 的引用，並實現存儲後鉤子函數來重新計算關聯投票中的總投票人數。
- 在 poll.ts 中引入存儲前鉤子以更新 `totalVoters` 字段，每當選項被修改或文檔是新創建時。
- 精簡 user model user.ts 來排除更多來自 `following.user` 和 `followers.user` 填充的字段。
- 在 option.router.ts 重構路由來包含路徑參數，作為投票操作的替代，而不是請求主體參數。
- 在 types/index.ts 修改 IOption 介面使 `user` 替代 `userId` 作為投票者的使用。