### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -1831,13 +1831,22 @@
             "Bearer": []
           }
         ]
-      },
+      }
+    },
+    "/api/option/vote/{id}": {
       "put": {
         "tags": [
           "Option - 投票及投票選項"
         ],
         "description": "更改投票",
         "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "選項ID"
+          },
           {
             "name": "body",
             "in": "body",
@@ -1846,10 +1855,6 @@
             "schema": {
               "type": "object",
               "properties": {
-                "optionId": {
-                  "type": "string",
-                  "example": "60f3e3e3e3e3e3e3e3e3e3e3"
-                },
                 "newOptionId": {
                   "type": "string",
                   "example": "54f3e3e3e3e3e3e3e3e3e3e3"
@@ -1920,38 +1925,11 @@
         "description": "取消投票",
         "parameters": [
           {
-            "name": "body",
-            "in": "body",
+            "name": "id",
+            "in": "path",
             "required": true,
-            "description": "取消投票",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "properties": {
-                  "type": "object",
-                  "properties": {
-                    "optionId": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    },
-                    "userId": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "example": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            "type": "string",
+            "description": "選項ID"
           }
         ],
         "responses": {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -37,6 +37,7 @@ app.use(
       { path: '/comment/', method: 'GET' },
       { path: '/option/', method: 'GET' },
       { path: '/poll/', method: 'GET' },
+      { path: '/mail/contact', method: 'POST' },
   ]),
   Routes,
 );

--- a/src/models/tokenBlacklist.ts
+++ b/src/models/tokenBlacklist.ts
@@ -11,7 +11,7 @@ const tokenBlacklistSchema = new Schema<ITokenBlacklist>({
     type: Date,
     required: true,
   },
-}, {
+},{
   versionKey: false,
     timestamps: true,
     toJSON: {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,7 +6,7 @@ import memberRouter from './member.router';
 import pollRouter from './poll.router';
 import commentRouter from './comment.router';
 import optionRouter from './option.router';
-
+import mailRouter from './mail.router';
 
 const apiRouter = Router();
 
@@ -20,11 +20,13 @@ apiRouter.use((req: Request, _, next: NextFunction) => {
   next();
 });
 
+
 apiRouter.use('/auth', authRouter);
 apiRouter.use('/imgur', imgurRouter);
 apiRouter.use('/member', memberRouter);
 apiRouter.use('/poll', pollRouter);
 apiRouter.use('/comment', commentRouter);
 apiRouter.use('/option', optionRouter);
+apiRouter.use('/mail', mailRouter);
 
 export default apiRouter;

--- a/src/routes/mail.router.ts
+++ b/src/routes/mail.router.ts
@@ -1,0 +1,15 @@
+import MailServiceController from '@/controllers/mailer.controller';
+
+import { handleErrorAsync } from '@/utils';
+
+import { Router } from 'express';
+
+const mailRouter = Router();
+
+mailRouter.post(
+  /**
+   * #swagger.ignore = true
+   */
+  '/contact', handleErrorAsync(MailServiceController.sendMail));
+
+export default mailRouter;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -73,7 +73,7 @@ export class Logger {
   }
   static log(message: string | Error, level: (typeof LogLevel)[number] = 'INFO') {
     const now: Date = new Date();
-    const formatTime = `${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+    const formatTime = `${now.toLocaleDateString('zh-TW', {timeZone: 'Asia/Taipei'})} ${now.toLocaleTimeString('zh-TW', {timeZone: 'Asia/Taipei'})}`;
     message =
       message instanceof Error ? `${message.name} ${message.message} ${message.stack}` : message;
     console.log(`[${level}] ${message} [${formatTime}]`);


### PR DESCRIPTION
功能：改進 API 端點及日誌配置

- 在 `/api/option/vote/{id}` 增加一個新的 API 端點用於透過 `PUT` 請求更新投票，並包含將 `id` 作為必需的字符串參數。
- 從投票更新端點的請求體結構中移除 `optionId` 並新增 `newOptionId`。
- 變更取消投票的端點，使用路徑中的 `id` 而非請求體。
- 通過更新中間件配置，允許對 `/mail/contact` 路徑的 `POST` 請求。
- 整合郵件功能，新增了 `mail.router.ts` 用於處理與電子郵件相關的路由。
- 調整日誌工具，使用 `'zh-TW'` 地區設定及 `'Asia/Taipei'` 時區來格式化時間戳記。