### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/ErrorSchema.ts
+++ b/develop/ErrorSchema.ts
@@ -101,4 +101,8 @@ export const ErrorSchema = {
     status: false,
     message: "沒有權限更新評論",
   },
+  ErrorContactFormat: {
+    status: false,
+    message: "請確實填寫聯絡資訊",
+  },
 };

--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -222,6 +222,12 @@ const doc = {
         edited: false,
       },
     ],
+    Contact: {
+      name: "John Doe",
+      email: "example@example.com",
+      message: "我想要聯絡你們。",
+      quests: "意見提供",
+    },
     // Error Response
     ...ErrorSchema,
   },

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -2163,6 +2163,117 @@
           }
         ]
       }
+    },
+    "/contact/": {
+      "post": {
+        "tags": [
+          "Contact - 聯絡我們與訂閱電子報"
+        ],
+        "description": "接收聯絡我們表單",
+        "parameters": [
+          {
+            "name": "contact",
+            "in": "body",
+            "description": "Contact us",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Contact"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "感謝您的留言"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "schema": {
+              "$ref": "#/definitions/ErrorContactFormat"
+            },
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/contact/subscribe": {
+      "post": {
+        "tags": [
+          "Contact - 聯絡我們與訂閱電子報"
+        ],
+        "description": "訂閱電子報",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "body",
+            "description": "Email",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "example": "example@example.com"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "感謝您的訂閱"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "請輸入正確的Email格式"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Bad Request"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -2756,6 +2867,27 @@
         }
       }
     },
+    "Contact": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "example": "John Doe"
+        },
+        "email": {
+          "type": "string",
+          "example": "example@example.com"
+        },
+        "message": {
+          "type": "string",
+          "example": "我想要聯絡你們。"
+        },
+        "quests": {
+          "type": "string",
+          "example": "意見提供"
+        }
+      }
+    },
     "ErrorTokenExpired": {
       "type": "object",
       "properties": {
@@ -3078,6 +3210,19 @@
         "message": {
           "type": "string",
           "example": "沒有權限更新評論"
+        }
+      }
+    },
+    "ErrorContactFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "請確實填寫聯絡資訊"
         }
       }
     }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -38,6 +38,8 @@ app.use(
       { path: '/option/', method: 'GET' },
       { path: '/poll/', method: 'GET' },
       { path: '/mail/contact', method: 'POST' },
+      { path: '/contact/', method: 'POST' },
+      { path: '/contact/subscribe', method: 'POST' },
   ]),
   Routes,
 );

--- a/src/controllers/contact.controller.ts
+++ b/src/controllers/contact.controller.ts
@@ -1,0 +1,45 @@
+import { RequestHandler } from "express";
+import { Contact } from "@/models";
+import { appError, successHandle } from "@/utils";
+import { object, string } from "yup";
+
+const contactSchema = object({
+  name: string().required("請輸入姓名"),
+  email: string().email("請輸入正確的Email格式").required("請輸入E-Mail"),
+  message: string().required("請輸入訊息"),
+});
+
+const emailSubscriberSchema = object({
+  email: string().email("請輸入正確的Email格式").required("請輸入E-Mail"),
+});
+
+class ContactController {
+  public static create: RequestHandler = async (req, res, next) => {
+    const validate = await contactSchema
+      .validate(req.body, { abortEarly: false })
+      .catch((err) => {
+        throw appError({ code: 400, message: err.errors.join(", "), next });
+      });
+    const { name, email, message } = validate;
+    const { quests } = req.body;
+    const contact = new Contact({ contact: { name, email, message, quests } });
+    await contact.save();
+    return successHandle(res, "感謝您的留言", {});
+  };
+
+  public static subscribe: RequestHandler = async (req, res, next) => {
+    const { email } = await emailSubscriberSchema.validate(req.body);
+    if (!email) {
+      throw appError({ code: 400, message: "請輸入正確的Email格式", next });
+    }
+    const contact = await Contact.findOne({ "emailSubscriber.email": email });
+    if (contact) {
+      throw appError({ code: 400, message: "您已經訂閱過了", next });
+    } else {
+      await Contact.updateOne({}, { $push: { emailSubscriber: { email } } });
+      return successHandle(res, "感謝您的訂閱", {});
+    }
+  };
+}
+
+export default ContactController;

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,0 +1,53 @@
+import { IContact } from '@/types';
+import { Schema, model } from 'mongoose';
+
+const contactSchema = new Schema<IContact>({
+  emailSubscriber: [
+    {
+      _id: false,
+      email: {
+        type: String,
+        required: true,
+      },
+      createdAt: {
+        type: Date,
+        default: Date.now,
+      },
+    },
+  ],
+  contact: [
+    {
+      _id: false,
+      name: {
+        type: String,
+        required: true,
+      },
+      email: {
+        type: String,
+        required: true,
+      },
+      message: {
+        type: String,
+        required: true,
+      },
+      quests: {
+        type: String,
+      },
+      createdAt: {
+        type: Date,
+        default: Date.now,
+      },
+    },
+  ],
+}, {
+  timestamps: { createdAt: 'createdTime', updatedAt: 'updateTime' },
+  versionKey: false,
+    toJSON: {
+      virtuals: true
+    },
+    toObject: {
+        virtuals: true
+    },
+});
+
+export default model<IContact>('Contact', contactSchema);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,3 +3,4 @@ export { default as Poll } from './poll';
 export { default as Option } from './option';
 export { default as Comment } from './comment';
 export { default as TokenBlacklist } from './tokenBlacklist';
+export { default as Contact } from './contact';

--- a/src/routes/contact.router.ts
+++ b/src/routes/contact.router.ts
@@ -1,0 +1,64 @@
+import ContactController from '@/controllers/contact.controller';
+
+import { handleErrorAsync } from '@/utils';
+
+import { Router } from 'express';
+
+const contactRouter = Router();
+
+contactRouter.post(
+  /**
+   * #swagger.tags = ['Contact - 聯絡我們與訂閱電子報']
+   * #swagger.description = '接收聯絡我們表單'
+    #swagger.parameters['contact'] = {
+    in: 'body',
+    description: 'Contact us',
+    required: true,
+    schema: { $ref: "#/definitions/Contact" }
+    }
+    * #swagger.responses[200] = {
+    schema: {
+        status: true,
+        message: "感謝您的留言",
+      },
+    }
+    * #swagger.responses[400] = {
+    schema: { $ref: "#/definitions/ErrorContactFormat" },
+    }
+   */
+  '/', handleErrorAsync(ContactController.create));
+
+contactRouter.post(
+  /**
+   * #swagger.tags = ['Contact - 聯絡我們與訂閱電子報']
+   * #swagger.description = '訂閱電子報'
+   * #swagger.parameters['email'] = {
+    in: 'body',
+    description: 'Email',
+    required: true,
+    schema: {
+    email: "example@example.com"
+    }
+  }
+  * #swagger.responses[200] = {
+    schema: {
+        status: true,
+        message: "感謝您的訂閱",
+      },
+    }
+    * #swagger.responses[400] = {
+    schema: {
+      status: false,
+      message: "您已經訂閱過了"
+    },
+    }
+    * #swagger.responses[400] = {
+    schema: {
+      status: false,
+      message: "請輸入正確的Email格式"
+    },
+    }
+   */
+  '/subscribe', handleErrorAsync(ContactController.subscribe));
+
+export default contactRouter;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import pollRouter from './poll.router';
 import commentRouter from './comment.router';
 import optionRouter from './option.router';
 import mailRouter from './mail.router';
+import contactRouter from './contact.router';
 
 const apiRouter = Router();
 
@@ -28,5 +29,6 @@ apiRouter.use('/poll', pollRouter);
 apiRouter.use('/comment', commentRouter);
 apiRouter.use('/option', optionRouter);
 apiRouter.use('/mail', mailRouter);
+apiRouter.use('/contact', contactRouter);
 
 export default apiRouter;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,20 @@
 import type { Request, Response, RequestHandler } from 'express';
 import { Document } from 'mongoose';
 
+export interface IContact extends Document {
+  emailSubscriber: {
+    email: string;
+    createdAt: Date;
+  }[];
+  contact: {
+    name: string;
+    email: string;
+    message: string;
+    quests: string;
+    createdAt: Date;
+  }[];
+}
+
 export interface IUser extends Document {
   id: string;
   name: string;


### PR DESCRIPTION
feat: 實作聯絡人管理端點

- 在 `ErrorSchema.ts` 中新增聯絡資訊驗證的錯誤訊息格式。
- 在 `swagger.ts` 中引入新的 `Contact` 結構作為用戶聯絡資訊。
- 在 `swagger_output.json` 中實作兩個新的 API 端點，用於接收聯絡表單和訂閱電子報。
- 在 `index.ts` 中新增路由以使用新的聯絡及訂閱端點。
- 創建新的 `contact.controller.ts`，內含創建聯絡項目和管理電子報訂閱的處理器。
- 引入新的 `contact.ts` 模型，用於處理資料庫中的聯絡資訊。
- 在模型目錄的 `index.ts` 中導出新的 `Contact` 模型。
- 新增 `contact.router.ts`，包含聯絡表單提交和電子報訂閱的路由。
- 更新路由目錄中的 `index.ts`，以包含新的聯絡路由。
- 在 `types/index.ts` 中定義新的 `IContact` 介面，用於聯絡資料類型結構。