### PR TITLE
GIT 提交訊息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -2164,7 +2164,7 @@
         ]
       }
     },
-    "/contact/": {
+    "/api/contact/": {
       "post": {
         "tags": [
           "Contact - 聯絡我們與訂閱電子報"
@@ -2210,7 +2210,7 @@
         }
       }
     },
-    "/contact/subscribe": {
+    "/api/contact/subscribe": {
       "post": {
         "tags": [
           "Contact - 聯絡我們與訂閱電子報"
@@ -2271,6 +2271,90 @@
               }
             },
             "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/api/contact/subscribe/": {
+      "put": {
+        "tags": [
+          "Contact - 聯絡我們與訂閱電子報"
+        ],
+        "description": "退訂電子報",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "body",
+            "description": "Email",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "type": "string",
+                  "example": "eyJhbGciOiJIUzI1NiJ9.dGxxxxxx"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "退訂成功，期待您再次訂閱電子報"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "您尚未訂閱過"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "message": {
+                  "type": "string",
+                  "example": "驗證失敗請確認是否有權限取消訂閱"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "Forbidden"
           }
         }
       }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -40,6 +40,7 @@ app.use(
       { path: '/mail/contact', method: 'POST' },
       { path: '/contact/', method: 'POST' },
       { path: '/contact/subscribe', method: 'POST' },
+      { path: '/contact/subscribe', method: 'PUT' },
   ]),
   Routes,
 );

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -1,23 +1,7 @@
-import { IContact } from '@/types';
+import { IContact, IEmailSubscriber } from '@/types';
 import { Schema, model } from 'mongoose';
 
 const contactSchema = new Schema<IContact>({
-  emailSubscriber: [
-    {
-      _id: false,
-      email: {
-        type: String,
-        required: true,
-      },
-      createdAt: {
-        type: Date,
-        default: Date.now,
-      },
-    },
-  ],
-  contact: [
-    {
-      _id: false,
       name: {
         type: String,
         required: true,
@@ -37,8 +21,6 @@ const contactSchema = new Schema<IContact>({
         type: Date,
         default: Date.now,
       },
-    },
-  ],
 }, {
   timestamps: { createdAt: 'createdTime', updatedAt: 'updateTime' },
   versionKey: false,
@@ -50,4 +32,30 @@ const contactSchema = new Schema<IContact>({
     },
 });
 
-export default model<IContact>('Contact', contactSchema);
+const subscriberSchema = new Schema<IEmailSubscriber>({
+  email: {
+    type: String,
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+  unScribedToken: {
+    type: String,
+    default: '',
+    select: false,
+  },
+}, {
+  timestamps: { createdAt: 'createdTime', updatedAt: 'updateTime' },
+  versionKey: false,
+    toJSON: {
+      virtuals: true
+    },
+    toObject: {
+        virtuals: true
+    },
+});
+
+export const Contact = model<IContact>('Contact', contactSchema);
+export const EmailSubscriber = model<IEmailSubscriber>('EmailSubscriber', subscriberSchema);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,4 +3,4 @@ export { default as Poll } from './poll';
 export { default as Option } from './option';
 export { default as Comment } from './comment';
 export { default as TokenBlacklist } from './tokenBlacklist';
-export { default as Contact } from './contact';
+export { Contact, EmailSubscriber  } from './contact';

--- a/src/routes/contact.router.ts
+++ b/src/routes/contact.router.ts
@@ -10,6 +10,7 @@ contactRouter.post(
   /**
    * #swagger.tags = ['Contact - 聯絡我們與訂閱電子報']
    * #swagger.description = '接收聯絡我們表單'
+   * #swagger.path = '/api/contact/'
     #swagger.parameters['contact'] = {
     in: 'body',
     description: 'Contact us',
@@ -32,6 +33,7 @@ contactRouter.post(
   /**
    * #swagger.tags = ['Contact - 聯絡我們與訂閱電子報']
    * #swagger.description = '訂閱電子報'
+   * #swagger.path = '/api/contact/subscribe'
    * #swagger.parameters['email'] = {
     in: 'body',
     description: 'Email',
@@ -60,5 +62,39 @@ contactRouter.post(
     }
    */
   '/subscribe', handleErrorAsync(ContactController.subscribe));
+
+contactRouter.put(
+  /**
+   * #swagger.tags = ['Contact - 聯絡我們與訂閱電子報']
+   * #swagger.description = '退訂電子報'
+   * #swagger.path = '/api/contact/subscribe/'
+   * #swagger.parameters['email'] = {
+    in: 'body',
+    description: 'Email',
+    required: true,
+    schema: {
+    token: "eyJhbGciOiJIUzI1NiJ9.dGxxxxxx"
+    }
+  }
+  * #swagger.responses[200] = {
+    schema: {
+        status: true,
+        message: "退訂成功，期待您再次訂閱電子報",
+      },
+    }
+    * #swagger.responses[400] = {
+    schema: {
+      status: false,
+      message: "您尚未訂閱過"
+    },
+    }
+    * #swagger.responses[403] = {
+    schema: {
+      status: false,
+      message: "驗證失敗請確認是否有權限取消訂閱"
+    },
+    }
+   */
+  '/subscribe', handleErrorAsync(ContactController.unsubscribe));
 
 export default contactRouter;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,17 +2,17 @@ import type { Request, Response, RequestHandler } from 'express';
 import { Document } from 'mongoose';
 
 export interface IContact extends Document {
-  emailSubscriber: {
-    email: string;
-    createdAt: Date;
-  }[];
-  contact: {
     name: string;
     email: string;
     message: string;
     quests: string;
     createdAt: Date;
-  }[];
+}
+
+export interface IEmailSubscriber extends Document {
+  email: string;
+  createdAt: Date;
+  unScribedToken: string;
 }
 
 export interface IUser extends Document {


### PR DESCRIPTION
feat: 重構聯絡人 API 和模型

- 為 Swagger 文檔中與聯絡人相關的路由加上 `/api` 前綴。
- 新增一個用於取消訂閱電子報的 API 端點，並提供相應的 Swagger 文檔。
- 在 Express 路由中重構與聯絡人相關的端點，以反映新的 API 前綴，並新增 PUT 路由用於取消訂閱。
- 用新的 `EmailSubscriber` 模型取代 `Contact` 模型中的 `emailSubscriber` 欄位，來處理訂閱事宜。
- 為聯絡人控制器中的新取消訂閱功能新增基於 JWT 的電子郵件令牌生成和驗證機制。
- 更新各種文件中的模型引入，以適應新的 `EmailSubscriber` 模型。
- 移除未使用的引入語句，並整理各種文件以提高結構性和可讀性。