### PR TITLE
GIT提交訊息：

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -100,6 +100,10 @@ const userSchema = new Schema<IUser>(
       type: String,
       select: false,
     },
+    githubId: {
+      type: String,
+      select: false,
+    },
     isValidator: {
       type: Boolean,
       default: false,

--- a/src/services/ThirdPartyService.ts
+++ b/src/services/ThirdPartyService.ts
@@ -95,6 +95,7 @@ export const useGoogleCallback = async (req, res, _next) =>
       avatar: picture,
       password: randomPassword(),
       googleId: id,
+      isValidator: true,
     });
     const authToken = generateToken({ userId: userData._id });
 
@@ -149,6 +150,7 @@ export const useFacebookCallback = async (req, res, _next) =>
       avatar: picture.data.url,
       password: randomPassword(),
       facebookId: id,
+      isValidator: true,
     });
     const authToken = generateToken({ userId: userData._id });
 
@@ -230,6 +232,7 @@ export const useLineCallback = async (req, res, _next) =>
       avatar: pictureUrl,
       password: randomPassword(),
       lineId: userId,
+      isValidator: true,
     });
     const authToken = generateToken({ userId: userData._id });
 
@@ -296,6 +299,7 @@ export const useDiscordCallback = async (req, res, _next) =>
       avatar,
       password: randomPassword(),
       discordId: id,
+      isValidator: true,
     });
     const authToken = generateToken({ userId: userData._id });
 
@@ -357,6 +361,7 @@ export const useGithubCallback = async (req, res, _next) =>
       avatar: avatar_url,
       password: randomPassword(),
       githubId: id,
+      isValidator: true,
     });
     const authToken = generateToken({ userId: userData._id });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface IUser extends Document {
   facebookId?: string;
   lineId?: string;
   discordId?: string;
+  githubId?: string;
   likedPolls: IPoll['_id'][];
 }
 


### PR DESCRIPTION
功能增強：提升用戶鑒權及架構

- 在`userSchema`中新增`githubId`字段，表示與GitHub帳戶的關聯。
- 在來自Google、Facebook、Line、Discord以及GitHub鑒權流程的回調中標記用戶為`isValidator`。
- 在`IUser`介面中包含`githubId`字段。