### PR TITLE
GIT提交訊息：

### DIFF
--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -27,7 +27,7 @@ const doc = {
   },
   definitions: {
     User: {
-      _id: "62e348927278654321000001",
+      id: "62e348927278654321000001",
       email: "johndoe@example.com",
       password: "hashed-password",
       name: "John Doe",
@@ -36,7 +36,7 @@ const doc = {
       followers: [
         {
           user: {
-            _id: "62e348927278654321000002",
+            id: "62e348927278654321000002",
             name: "Jane Doe",
             avatar: "https://i.imgur.com/xcLTrkV.png",
           },
@@ -46,7 +46,7 @@ const doc = {
       following: [
         {
           user: {
-            _id: "62e348927278654321000003",
+            id: "62e348927278654321000003",
             name: "Bob Smith",
             avatar: "https://i.imgur.com/xcLTrkV.png",
           },
@@ -77,7 +77,7 @@ const doc = {
       ],
     },
     Member: {
-      _id: "62e348927278654321000001",
+      id: "62e348927278654321000001",
       name: "John Doe",
       avatar: "https://i.imgur.com/xcLTrkV.png",
       gender: "male",
@@ -95,7 +95,7 @@ const doc = {
       followers: [
         {
           user: {
-            _id: "62e348927278654321000002",
+            id: "62e348927278654321000002",
             name: "Mary Johnson",
             avatar: "https://i.imgur.com/xcLTrkV.png",
           },
@@ -112,10 +112,9 @@ const doc = {
           id: "johndoe",
         },
       ],
-      id: "62e348927278654321000001",
       likedPolls: [
         {
-          _id: "62e348927278654321000001",
+          id: "62e348927278654321000001",
           title: "最喜歡的程式語言",
           imageUrl: "https://i.imgur.com/D3hp8H6.png",
         },

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -2172,7 +2172,7 @@
     "User": {
       "type": "object",
       "properties": {
-        "_id": {
+        "id": {
           "type": "string",
           "example": "62e348927278654321000001"
         },
@@ -2204,7 +2204,7 @@
               "user": {
                 "type": "object",
                 "properties": {
-                  "_id": {
+                  "id": {
                     "type": "string",
                     "example": "62e348927278654321000002"
                   },
@@ -2233,7 +2233,7 @@
               "user": {
                 "type": "object",
                 "properties": {
-                  "_id": {
+                  "id": {
                     "type": "string",
                     "example": "62e348927278654321000003"
                   },
@@ -2320,7 +2320,7 @@
     "Member": {
       "type": "object",
       "properties": {
-        "_id": {
+        "id": {
           "type": "string",
           "example": "62e348927278654321000001"
         },
@@ -2377,7 +2377,7 @@
               "user": {
                 "type": "object",
                 "properties": {
-                  "_id": {
+                  "id": {
                     "type": "string",
                     "example": "62e348927278654321000002"
                   },
@@ -2414,16 +2414,12 @@
             }
           }
         },
-        "id": {
-          "type": "string",
-          "example": "62e348927278654321000001"
-        },
         "likedPolls": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "_id": {
+              "id": {
                 "type": "string",
                 "example": "62e348927278654321000001"
               },

--- a/src/app/server.ts
+++ b/src/app/server.ts
@@ -11,14 +11,18 @@ const { DATABASE_PASSWORD, DATABASE_PATH } = process.env;
 
 const isProduction = process.env.NODE_ENV === "production";
 
-import agenda from "@/services/AgendaService";
+import { agenda, initializeAgenda} from "@/services/AgendaService";
 import { catchGlobalError } from "./exception";
 
 mongoose.set("strictQuery", false);
 
 mongoose
   .connect(DATABASE_PATH?.replace("<password>", `${DATABASE_PASSWORD}`) ?? "")
-  .then(() => Logger.log("資料庫連線成功"))
+  .then(() => {
+    Logger.log("資料庫連線成功");
+
+    initializeAgenda().then(() => Logger.log("Agenda 初始化完成"));
+  })
   .catch((error) => Logger.warn(`資料庫連線錯誤: ${error.message}`));
 
 const port = parseInt(process.env.PORT || "8081");
@@ -31,12 +35,6 @@ const wss = new WebSocketServer({ port: 8082 });
 initWebSocketServer(wss, server);
 app.use(attachWsToRequest(wss));
 webSocketService(wss);
-
-agenda.on("ready", () =>
-{
-  Logger.log('Agenda is ready');
-  agenda.start();
-});
 
 server.on("error", (error) => {
   Logger.error(`伺服器錯誤： ${error}`);
@@ -51,8 +49,13 @@ if (!isProduction) {
 
 catchGlobalError();
 
-process.on("SIGINT", () => {
+process.on("SIGINT", async () => {
+  await agenda.stop();
+  Logger.log('Agenda has been stopped.');
+
   server.close(() => {
+    Logger.log('HTTP server closed.');
     process.exit(0);
   });
 });
+

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -152,7 +152,7 @@ class AuthController {
     if (!user) {
       throw appError({ code: 404, message: "無效的重設連結或已過期", next });
     }
-    await User.findByIdAndUpdate(user._id, { resetToken: "", password }).exec();
+    await User.findByIdAndUpdate(user.id, { resetToken: "", password }).exec();
     return successHandle(_res, "成功重設密碼", { result: true });
   };
 

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -27,8 +27,8 @@ class CommentController {
         content,
         pollId,
       });
-    await User.findByIdAndUpdate(id, { $push: { comments: comment._id } });
-    const result = await Poll.findByIdAndUpdate({ _id: pollId }, { $push: { comments: { comment } } }, { new: true });
+    await User.findByIdAndUpdate(id, { $push: { comments: comment.id } });
+    const result = await Poll.findByIdAndUpdate({ id: pollId }, { $push: { comments: { comment } } }, { new: true });
     successHandle(res, '評論創建成功', { result });
   };
 
@@ -65,7 +65,7 @@ class CommentController {
       if (!deletedComment) {
         throw appError({ code: 404, message: '找不到評論', next});
       }
-    const result = await Poll.findByIdAndUpdate({ _id: deletedComment.pollId }, { $pull: { comments: { comment: id } } }, { new: true });
+    const result = await Poll.findByIdAndUpdate({ id: deletedComment.pollId }, { $pull: { comments: { comment: id } } }, { new: true });
     await User.findByIdAndUpdate(userId, { $pull: { comments: id } });
     successHandle(res, '評論刪除成功', {result});
   };

--- a/src/controllers/imgur.controller.ts
+++ b/src/controllers/imgur.controller.ts
@@ -35,7 +35,7 @@ class ImgurController {
         const response = await client.upload({
           image: req.files[0].buffer.toString('base64'),
           type: 'base64',
-          album: process.env.IMGUR_ALBUM_ID,
+          album: process.env.IMGUR_ALBUMid,
         });
         successHandle(res, '成功上傳圖片', { result: response.data.link });
       } catch (error) {

--- a/src/controllers/mailer.controller.ts
+++ b/src/controllers/mailer.controller.ts
@@ -69,7 +69,7 @@ export class MailServiceController {
     }
     // 生成新的 token
     const newVerificationToken = jwt.sign(
-      { userId: user._id },
+      { userId: user.id },
       process.env.JWT_SECRET as string,
       { expiresIn: "24h" } // Token 有效期 24 小时
     );
@@ -130,8 +130,8 @@ export class MailServiceController {
       });
     }
 
-    const token = generateToken({ userId: user._id });
-    await User.findByIdAndUpdate(user._id, { resetToken: token });
+    const token = generateToken({ userId: user.id });
+    await User.findByIdAndUpdate(user.id, { resetToken: token });
 
     await MailServiceController.transporter.verify();
     const info = await MailServiceController.transporter.sendMail({

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -93,19 +93,19 @@ class MemberController {
     const isAlreadyFollowing =
       user.following &&
       user.following.some(
-        (following) => following.user._id.toString() === targetID
+        (following) => following.user.id.toString() === targetID
       );
     if (isAlreadyFollowing)
       throw appError({ code: 400, message: "您已經追蹤了該使用者", next });
 
     const resultUserData = await User.findOneAndUpdate(
-      { _id: id, "following.user": { $ne: targetID } },
+      { id, "following.user": { $ne: targetID } },
       { $addToSet: { following: { user: targetID } } },
       { new: true }
     ).select("-coin -updatedAt -isValidator -isSubscribed");
 
     await User.findOneAndUpdate(
-      { _id: targetID },
+      { id: targetID },
       { $addToSet: { followers: { user: id } } }
     );
 
@@ -129,7 +129,7 @@ class MemberController {
     const isFollowing =
       user.following &&
       user.following.some(
-        (following) => following.user._id.toString() === targetID
+        (following) => following.user.id.toString() === targetID
       );
     if (!isFollowing)
       throw appError({
@@ -139,12 +139,12 @@ class MemberController {
       });
 
     await User.findOneAndUpdate(
-      { _id: id },
+      { id: id },
       { $pull: { following: { user: targetID } } }
     );
 
     await User.findOneAndUpdate(
-      { _id: targetID },
+      { id: targetID },
       { $pull: { followers: { user: id } } }
     );
 

--- a/src/controllers/vote.controller.ts
+++ b/src/controllers/vote.controller.ts
@@ -9,7 +9,7 @@ class VoteController {
     const { id } = req.user as IUser;
     const poll = await Poll.findOne({ options: optionId });
     const vote = await Vote.findById(optionId);
-    const user = await User.findOne({ _id: id });
+    const user = await User.findOne({ id: id });
 
     if (!poll) {
       throw appError({ code: 404, message: "找不到投票", next });
@@ -27,7 +27,7 @@ class VoteController {
 
     // 添加投票者
     const updatedVote = await Vote.findByIdAndUpdate(
-      { _id: optionId },
+      { id: optionId },
       { $push: { voters: { user, createdTime: new Date() } } },
       { new: true }
     )
@@ -44,7 +44,7 @@ class VoteController {
     const { newVoteId } = req.body;
 
     const vote = await Vote.findById(voteId);
-    const user = await User.findOne({ _id: id });
+    const user = await User.findOne({ id: id });
     const poll = await Poll.findOne({ votes: voteId });
 
     if (!poll) {

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -25,10 +25,20 @@ const contactSchema = new Schema<IContact>({
   timestamps: { createdAt: 'createdTime', updatedAt: 'updateTime' },
   versionKey: false,
     toJSON: {
-      virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
     toObject: {
-        virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
 });
 

--- a/src/models/poll.ts
+++ b/src/models/poll.ts
@@ -48,14 +48,12 @@ const pollSchema = new Schema<IPoll>({
   },
   options: [
     {
-      _id: false,
       type: Schema.Types.ObjectId,
       ref: 'Vote',
     },
   ],
   like: [
     {
-      _id: false,
       user: {
         type: Schema.Types.ObjectId,
         ref: 'User',
@@ -64,7 +62,6 @@ const pollSchema = new Schema<IPoll>({
   ],
   comments: [
     {
-      _id: false,
       comment: {
         type: Schema.Types.ObjectId,
         ref: 'Comment',
@@ -89,10 +86,20 @@ const pollSchema = new Schema<IPoll>({
   versionKey: false,
     timestamps: true,
     toJSON: {
-      virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
     toObject: {
-        virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
 });
 
@@ -123,7 +130,7 @@ pollSchema.post('save', async function() {
   wss.clients.forEach(client => {
     client.send(JSON.stringify({
       type: 'pollUpdate',
-      pollId: this._id,
+      pollId: this.id,
       totalVoters: this.totalVoters,
     }));
   });
@@ -149,6 +156,16 @@ pollSchema.pre(/^find/, function (next)
   )
   next();
 });
+
+// 考慮性能，只在需要時進行關聯查詢
+pollSchema.virtual('optionsDetails', {
+  ref: 'Vote',
+  localField: 'options',
+  foreignField: '_id',
+});
+
+// 索引優化
+pollSchema.index({ createdBy: 1, startDate: 1, endDate: 1, status: 1 });
 
 
 export default model<IPoll>('Poll', pollSchema);

--- a/src/models/tokenBlacklist.ts
+++ b/src/models/tokenBlacklist.ts
@@ -15,10 +15,20 @@ const tokenBlacklistSchema = new Schema<ITokenBlacklist>({
   versionKey: false,
     timestamps: true,
     toJSON: {
-      virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
     toObject: {
-        virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
 });
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -15,6 +15,7 @@ const userSchema = new Schema<IUser>(
         },
         message: '請填寫正確 email 格式',
       },
+      index: true,
       unique: true,
       select: false,
     },
@@ -149,18 +150,43 @@ const userSchema = new Schema<IUser>(
     versionKey: false,
     timestamps: true,
     toJSON: {
-      virtuals: true
+      virtuals: true,
+      transform: (_doc, ret) =>
+      {
+        ret.id = ret._id;
+        delete ret._id;
+        delete ret.password;
+        delete ret.resetToken;
+        delete ret.verificationToken;
+        return ret;
+      }
     },
     toObject: {
-        virtuals: true
+      virtuals: true,
+      transform: (_doc, ret) =>
+      {
+        ret.id = ret._id;
+        delete ret._id;
+        delete ret.password;
+        delete ret.resetToken;
+        delete ret.verificationToken;
+        return ret;
+      }
     },
   },
 );
 
-userSchema.pre('save', async function (next) {
-  if (!this.isModified('password')) return next();
-  const salt = await bcrypt.genSalt(10);
-  this.password = await bcrypt.hash(this.password, salt);
+userSchema.pre('save', async function (next)
+{
+  // 如果 email 字段被修改了，則轉換為小寫
+  if (this.isModified('email')) {
+    this.email = this.email.trim().toLowerCase();
+  }
+  // 如果密碼被修改了，則對密碼進行加密
+  if (this.isModified('password')) {
+    const salt = await bcrypt.genSalt(12);
+    this.password = await bcrypt.hash(this.password, salt);
+  }
   next();
 });
 
@@ -179,14 +205,11 @@ userSchema.post('save', async function() {
   }
 });
 
-userSchema.statics.findWithoutSensitiveData = function (query) {
-  return this.find(query).select('-password -resetToken');
-};
-
 userSchema.methods.toJSON = function () {
   const user = this.toObject();
   delete user.password;
   delete user.resetToken;
+  delete user.verificationToken;
   return user;
 };
 

--- a/src/models/vote.ts
+++ b/src/models/vote.ts
@@ -39,10 +39,20 @@ const voteSchema = new Schema<IVote>({
   versionKey: false,
     timestamps: true,
     toJSON: {
-      virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
     toObject: {
-        virtuals: true
+      virtuals: true,
+      transform: function (_doc, ret)
+      {
+        ret.id = ret._id;
+        delete ret._id;
+      }
     },
 });
 
@@ -52,7 +62,7 @@ voteSchema.post('save', async function(doc, next) {
 });
 
 async function recalculateTotalVoters(pollId: string) {
-  const VoteModel = model('Option');
+  const VoteModel = model('Vote');
   const totalVoters = await VoteModel.aggregate([
     { $match: { pollId: pollId } },
     { $unwind: '$voters' },
@@ -70,5 +80,8 @@ voteSchema.pre(/^find/, function(next) {
   }]);
   next();
 });
+
+// 索引優化
+voteSchema.index({ pollId: 1 });
 
 export default model<IVote>('Vote', voteSchema);

--- a/src/routes/poll.router.ts
+++ b/src/routes/poll.router.ts
@@ -23,6 +23,21 @@ pollRouter.get(
     type: 'number',
     description: '每頁記錄數',
   }
+  * #swagger.parameters['q'] = {
+    in: 'query',
+    required: false,
+    type: 'string',
+    description: '搜尋關鍵字',
+  }
+  * #swagger.parameters['status'] = {
+    in: 'query',
+    required: false,
+    type: 'string',
+    schema: {
+      enum: ["active", "pending", "closed"],
+    },
+    description: '提案狀態',
+  }
   * #swagger.responses[200] = {
     schema: {
       status: true,

--- a/src/services/AgendaService.ts
+++ b/src/services/AgendaService.ts
@@ -3,7 +3,6 @@ import { Logger } from "@/utils";
 import { PollService } from './PollCheckService';
 import { AuthService } from './AuthService';
 
-
 const dbPath = process.env.DATABASE_PATH || '';
 const dbPassword = process.env.DATABASE_PASSWORD || '';
 
@@ -17,19 +16,21 @@ agenda.define('check poll status', async () => {
   await PollService.startPollCheckService();
 });
 
-await agenda.start();
-await agenda.every('1 minute', 'check poll status');
 
 agenda.define('update validation tokens', async () => {
   Logger.log('Running a job at 01:00 to update verification tokens');
   await AuthService.updateValidationToken();
 });
 
-await agenda.start();
-await agenda.schedule('1 day at 01:00', 'update validation tokens', { timezone: 'Asia/Taipei' });
-
 agenda.on('start', job => Logger.log(`Job ${job.attrs.name} started`));
 agenda.on('complete', job => Logger.log(`Job ${job.attrs.name} finished`));
 agenda.on('fail', (err, job) => Logger.log(`Job ${job.attrs.name} failed with error: ${err.message}`));
 
-export default agenda;
+async function initializeAgenda() {
+  await agenda.start();
+
+  await agenda.every('1 minute', 'check poll status');
+  await agenda.schedule('1 day at 01:00', 'update validation tokens', {});
+}
+
+export { agenda, initializeAgenda };

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -70,7 +70,7 @@ export class AuthService {
       });
 
       const verificationToken = jwt.sign(
-        { userId: memberData._id },
+        { userId: memberData.id },
         process.env.JWT_SECRET as string,
         { expiresIn: '24h' }
       );
@@ -78,7 +78,7 @@ export class AuthService {
       await memberData.save();
 
       const publicMember: Omit<Member, 'passhash'> = {
-        id: memberData._id,
+        id: memberData.id,
         email: memberData.email,
         name: memberData.name,
       };
@@ -127,11 +127,11 @@ export class AuthService {
       userData = user;
     }
 
-    token = generateToken({ userId: userData._id });
+    token = generateToken({ userId: userData.id });
 
     const authParams = new URLSearchParams([
       ['token', token],
-      ['id', userData._id as string],
+      ['id', userData.id as string],
       ['avatar', userData.avatar || ''],
       ['name', userData.name],
     ]).toString();
@@ -170,7 +170,7 @@ export class AuthService {
     users.forEach(async (user) =>
     {
       const newVerificationToken = jwt.sign(
-        { userId: user._id },
+        { userId: user.id },
         process.env.JWT_SECRET as string,
         { expiresIn: '24h' } // 根據需要調整過期時間
       );

--- a/src/services/PollCheckService.ts
+++ b/src/services/PollCheckService.ts
@@ -21,13 +21,12 @@ export class PollService
 
       const pollsToEnd = await Poll.find({ endDate: { $lte: now }, status: 'ended' });
 
+      for (let poll of pollsToEnd) {
+        await PollController.calculateResultsForPoll(poll._id.toString());
+      }
       const totalPollsToEnd = await Poll.countDocuments({ status: 'closed' });
 
       Logger.log(`目前有 ${ totalPollsToEnd } 筆投票已經結束`, 'INFO');
-
-      for (let poll of pollsToEnd) {
-        await PollController.calculateResultsForPoll(poll._id);
-      }
 
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,12 @@
-import type { Request, Response, RequestHandler } from 'express';
-import { Document } from 'mongoose';
+import type { Request, Response, RequestHandler } from "express";
+import { Document } from "mongoose";
 
 export interface IContact extends Document {
-    name: string;
-    email: string;
-    message: string;
-    quests: string;
-    createdAt: Date;
+  name: string;
+  email: string;
+  message: string;
+  quests: string;
+  createdAt: Date;
 }
 
 export interface IEmailSubscriber extends Document {
@@ -21,20 +21,20 @@ export interface IUser extends Document {
   email: string;
   password: string;
   avatar: string;
-  gender: 'male' | 'female' | 'x';
+  gender: "male" | "female" | "x";
   birthday?: Date;
   socialMedia?: [
     {
       type: string;
       id: string;
-    },
+    }
   ];
   followers?: {
-    user: IUser['_id'];
+    user: IUser["_id"];
     createdAt: Date;
   }[];
   following?: {
-    user: IUser['_id'];
+    user: IUser["_id"];
     createdAt: Date;
   }[];
   isValidator: boolean;
@@ -48,8 +48,8 @@ export interface IUser extends Document {
   lineId?: string;
   discordId?: string;
   githubId?: string;
-  likedPolls: IPoll[ '_id' ][];
-  comments: IComment[ '_id' ][];
+  likedPolls: IPoll["_id"][];
+  comments: IComment["_id"][];
 }
 
 export interface CreateUserRequest {
@@ -57,14 +57,14 @@ export interface CreateUserRequest {
   password: string;
   name?: string;
   avatar?: string;
-  gender?: 'male' | 'female' | 'x';
+  gender?: "male" | "female" | "x";
   socialMedia?: Array<{ type: string; id: string }>;
 }
 
 export interface UpdateUserRequest {
   name?: string;
   avatar?: string;
-  gender?: 'male' | 'female' | 'x';
+  gender?: "male" | "female" | "x";
 }
 export interface IPoll extends Document {
   id: string;
@@ -79,19 +79,18 @@ export interface IPoll extends Document {
   isPrivate: boolean;
   totalVoters: number;
   like: {
-    user: IUser['_id'];
+    user: IUser["_id"];
   }[];
   comments: {
-    comment: IComment['_id'];
+    comment: IComment["_id"];
   }[];
   options: {
-    optionId: IVote['_id'];
+    optionId: IVote["_id"];
   }[];
-  status: 'pending' | 'active' | 'ended' | 'closed';
-  isWinner:
-    {
-      options: IVote['_id'];
-    }[];
+  status: "pending" | "active" | "ended" | "closed";
+  isWinner: {
+    option: IVote["_id"];
+  }[];
 }
 
 export interface CreatePollRequest {
@@ -105,15 +104,21 @@ export interface CreatePollRequest {
 }
 
 export interface IVote extends Document {
-  id?: string;
+  id: string;
   title: string;
   imageUrl: string;
-  pollId: IPoll['_id'];
+  pollId: IPoll["_id"];
   voters: {
-    user: IUser['_id'];
+    user: IUser["_id"];
     createdTime: Date;
   }[];
   isWinner: boolean;
+}
+
+export interface IOption {
+  title: string;
+  imageUrl?: string;
+  id?: string;
 }
 
 export interface CreateOptionRequest {
@@ -123,9 +128,9 @@ export interface CreateOptionRequest {
 }
 
 export interface IComment extends Document {
-  _id?: string;
-  author: IUser['_id'];
-  pollId: IPoll['_id'];
+  id: string;
+  author: IUser["_id"];
+  pollId: IPoll["_id"];
   content: string;
   createdTime: Date;
   edited: boolean;
@@ -139,7 +144,7 @@ export interface CreateCommentRequest {
 }
 
 export interface ITokenBlacklist extends Document {
-  _id?: string;
+  id: string;
   token: string;
   expiresAt: Date;
 }
@@ -202,12 +207,9 @@ export type TokenPayload = {
   exp: number;
 };
 
-declare global
-{
-  namespace Express
-  {
-    export interface Request
-    {
+declare global {
+  namespace Express {
+    export interface Request {
       headers: {
         authorization?: string;
       };


### PR DESCRIPTION
重構：重構標識符並優化後端

- 將Swagger模型屬性從`_id`重構為`id`，適用於用戶和會員對象，在多個結構如API文檔和JSON輸出的定義和屬性中。
- 更新伺服器代碼以在一個獨立的導出函數內初始化Agenda任務排程，以增進整潔性和控制性。
- 修改參考`IMGUR_ALBUM_ID`的常量為`IMGUR_ALBUMid`，這可能反映了imgur相簿配置的變數名稱變更。
- 更新路由、模型和控制器邏輯，從使用`_id`切換到使用`id`作為用戶和民意調查相關操作的標識符，以創建更一致的標識符使用。
- 在Mongoose架構中引入虛擬欄位和額外索引進行優化，確保更高效的數據庫查詢性能。
- 若干零雜的代碼改進，例如處理電子郵件可能的大小寫敏感性問題，確保在數據回傳給客戶端前適當刪除敏感信息，以及輕微的抽象代碼改進。