### PR TITLE
GIT 提交信息：

### DIFF
--- a/develop/ErrorSchema.ts
+++ b/develop/ErrorSchema.ts
@@ -11,7 +11,7 @@ export const ErrorSchema = {
     status: false,
     message: "缺少 Token",
   },
-  ErrorUserNotFound: {
+  ErrorEmailNotFound: {
     status: false,
     message: "已無此使用者請重新註冊 | 請確認 Email 是否正確 | 此 Email 未註冊",
   },

--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -159,7 +159,7 @@ authRouter.get(
   }
   * #swagger.responses[404] = {
     schema: {
-      $ref: "#/definitions/ErrorUserNotFound"
+      $ref: "#/definitions/ErrorEmailNotFound"
     },
     description: "取得使用者資訊失敗"
   }
@@ -189,7 +189,7 @@ authRouter.post(
   }
   * #swagger.responses[404] = {
     schema: {
-      $ref: "#/definitions/ErrorUserNotFound"
+      $ref: "#/definitions/ErrorEmailNotFound"
     },
     description: "重設密碼失敗"
   }
@@ -244,7 +244,7 @@ authRouter.post(
   }
   * #swagger.responses[404] = {
     schema: {
-    $ref: "#/definitions/ErrorUserNotFound"
+    $ref: "#/definitions/ErrorEmailNotFound"
     },
     description: "更新密碼失敗"
   }


### PR DESCRIPTION
重構：重構錯誤命名及參考

- 在 ErrorSchema 定義中將錯誤 `ErrorUserNotFound` 重命名為 `ErrorEmailNotFound`
- 在 auth.router.ts 的 swagger 回應中更新從 `ErrorUserNotFound` 到 `ErrorEmailNotFound` 的參考

記住翻譯所有給定的 git 提交信息。

Signed-off-by: huan5678 <huan5678@gmail.com>