### PR TITLE
GIT 提交資訊:

### DIFF
--- a/develop/swagger.ts
+++ b/develop/swagger.ts
@@ -18,7 +18,7 @@ const doc = {
     `,
   },
   securityDefinitions: {
-    bearerAuth: {
+    Bearer: {
       type: "apiKey",
       in: "header",
       name: "authorization",

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -11,7 +11,7 @@
     "http"
   ],
   "securityDefinitions": {
-    "bearerAuth": {
+    "Bearer": {
       "type": "apiKey",
       "in": "header",
       "name": "authorization",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -26,6 +26,7 @@ app.use(
     [
       { path: '/auth/login', method: 'POST' },
       { path: '/auth/register', method: 'POST' },
+      { path: '/auth/reset-password', method: 'POST' },
       { path: '/auth/reset-password', method: 'PUT' },
       { path: '/auth/verify', method: 'GET' },
       { path: '/auth/verify', method: 'POST' },

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -1,83 +1,96 @@
-import { RequestHandler } from 'express';
-import { Comment, Poll, User } from '@/models';
-import { appError, successHandle } from '@/utils';
-import { object, string } from 'yup';
-import { IUser } from '@/types';
+import { RequestHandler } from "express";
+import { Comment, Poll, User } from "@/models";
+import { appError, successHandle, validateInput } from "@/utils";
+import { object, string } from "yup";
+import { IUser } from "@/types";
 
 const createCommentSchema = object({
-  pollId: string().required('請輸入投票ID'),
-  content: string().required('請輸入評論內容').min(1, '評論內容請大於 1 個字').max(200, '評論內容長度過長，最多只能 200 個字'),
+  pollId: string().required("請輸入投票ID"),
+  content: string()
+    .required("請輸入評論內容")
+    .min(1, "評論內容請大於 1 個字")
+    .max(200, "評論內容長度過長，最多只能 200 個字"),
 });
 
 const updateCommentSchema = object({
-  content: string().required('請輸入評論內容').min(1, '評論內容請大於 1 個字').max(200, '評論內容長度過長，最多只能 200 個字'),
+  content: string()
+    .required("請輸入評論內容")
+    .min(1, "評論內容請大於 1 個字")
+    .max(200, "評論內容長度過長，最多只能 200 個字"),
 });
 
 class CommentController {
   // 創建新評論
   public static createComment: RequestHandler = async (req, res, next) => {
-      const { id } = req.user as IUser;
-      const validationResult = await createCommentSchema.validate(req.body);
-      if (!validationResult) {
-        throw appError({ code: 400, message: '請確實填寫評論資訊', next});
-      }
-      const { content, pollId } = req.body;
-      const comment = await Comment.create({
-        author: id,
-        content,
-        pollId,
-      });
+    const { id } = req.user as IUser;
+    if (!(await validateInput(createCommentSchema, req.body, next))) return;
+
+    const { content, pollId } = req.body;
+    const comment = await Comment.create({
+      author: id,
+      content,
+      pollId,
+    });
     await User.findByIdAndUpdate(id, { $push: { comments: comment.id } });
-    const result = await Poll.findByIdAndUpdate({ id: pollId }, { $push: { comments: { comment } } }, { new: true });
-    successHandle(res, '評論創建成功', { result });
+    const result = await Poll.findByIdAndUpdate(
+      { id: pollId },
+      { $push: { comments: { comment } } },
+      { new: true }
+    );
+    successHandle(res, "評論創建成功", { result });
   };
 
   // 更新評論
   public static updateComment: RequestHandler = async (req, res, next) => {
-      const { id } = req.user as IUser;
-      const validationResult = await updateCommentSchema.validate(req.body);
-      if (!validationResult) {
-        throw appError({ code: 400, message: '請確實填寫評論資訊', next});
-      }
+    const { id } = req.user as IUser;
+    if (!(await validateInput(updateCommentSchema, req.body, next))) return;
+
     const commentId = req.params.id;
-      const { content } = req.body;
+    const { content } = req.body;
     const comment = await Comment.findById(commentId);
-      if (!comment) {
-        throw appError({
-          code: 404, message: '找不到評論', next});
-      }
-      if (comment.author.id !== id) {
-        throw appError({ code: 403, message: '沒有權限更新評論', next});
-      }
-      const updatedComment = await Comment.findByIdAndUpdate(
-        commentId,
-        { content, edited: true, updateTime: Date.now() },
-        { new: true },
-      );
-      successHandle(res, '評論更新成功', { updatedComment });
+    if (!comment) {
+      throw appError({
+        code: 404,
+        message: "找不到評論",
+        next,
+      });
+    }
+    if (comment.author.id !== id) {
+      throw appError({ code: 403, message: "沒有權限更新評論", next });
+    }
+    const updatedComment = await Comment.findByIdAndUpdate(
+      commentId,
+      { content, edited: true, updateTime: Date.now() },
+      { new: true }
+    );
+    successHandle(res, "評論更新成功", { updatedComment });
   };
 
   // 刪除評論
   public static deleteComment: RequestHandler = async (req, res, next) => {
     const { id } = req.params;
     const { id: userId } = req.user as IUser;
-      const deletedComment = await Comment.findByIdAndDelete(id).exec();
-      if (!deletedComment) {
-        throw appError({ code: 404, message: '找不到評論', next});
-      }
-    const result = await Poll.findByIdAndUpdate({ id: deletedComment.pollId }, { $pull: { comments: { comment: id } } }, { new: true });
+    const deletedComment = await Comment.findByIdAndDelete(id).exec();
+    if (!deletedComment) {
+      throw appError({ code: 404, message: "找不到評論", next });
+    }
+    const result = await Poll.findByIdAndUpdate(
+      { id: deletedComment.pollId },
+      { $pull: { comments: { comment: id } } },
+      { new: true }
+    );
     await User.findByIdAndUpdate(userId, { $pull: { comments: id } });
-    successHandle(res, '評論刪除成功', {result});
+    successHandle(res, "評論刪除成功", { result });
   };
 
   // 獲取特定評論
   public static getComment: RequestHandler = async (req, res, next) => {
-      const { id } = req.params;
-      const comment = await Comment.findById(id).exec();
-      if (!comment) {
-        throw appError({ code: 404, message: '找不到評論', next });
-      }
-      successHandle(res, '獲取評論成功', { comment });
+    const { id } = req.params;
+    const comment = await Comment.findById(id).exec();
+    if (!comment) {
+      throw appError({ code: 404, message: "找不到評論", next });
+    }
+    successHandle(res, "獲取評論成功", { comment });
   };
 }
 

--- a/src/controllers/contact.controller.ts
+++ b/src/controllers/contact.controller.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from "express";
 import jsonWebToken from 'jsonwebtoken';
 import { Contact, EmailSubscriber } from "@/models";
-import { appError, successHandle } from "@/utils";
+import { appError, successHandle, validateInput } from "@/utils";
 import { object, string } from "yup";
 
 const { JWT_SECRET } = process.env;
@@ -17,14 +17,10 @@ const emailSubscriberSchema = object({
 });
 
 class ContactController {
-  public static create: RequestHandler = async (req, res, next) => {
-    const validate = await contactSchema
-      .validate(req.body, { abortEarly: false })
-      .catch((err) => {
-        throw appError({ code: 400, message: err.errors.join(", "), next });
-      });
-    const { name, email, message } = validate;
-    const { quests } = req.body;
+  public static create: RequestHandler = async (req, res, next) =>
+  {
+    if (!(await validateInput(contactSchema, req.body, next))) return;
+    const { name, email, message, quests } = req.body;
     const contact = new Contact({ contact: { name, email, message, quests } });
     await contact.save();
     return successHandle(res, "感謝您的留言", {});

--- a/src/controllers/imgur.controller.ts
+++ b/src/controllers/imgur.controller.ts
@@ -1,8 +1,7 @@
 import { RequestHandler } from 'express';
 import multer from 'multer';
 import path from 'path';
-const Imgur = await import('imgur');
-const ImgurClient = Imgur.ImgurClient;
+import { ImgurClient } from 'imgur';
 import { appError, successHandle } from '@/utils';
 
 const client = new ImgurClient({
@@ -35,8 +34,11 @@ class ImgurController {
         const response = await client.upload({
           image: req.files[0].buffer.toString('base64'),
           type: 'base64',
-          album: process.env.IMGUR_ALBUMid,
+          album: process.env.IMGUR_ALBUM_ID,
         });
+        if (response.success !== true) {
+          throw appError({ code: 500, message: '上傳失敗', next });
+        }
         successHandle(res, '成功上傳圖片', { result: response.data.link });
       } catch (error) {
         if (error instanceof Error) {

--- a/src/controllers/mailer.controller.ts
+++ b/src/controllers/mailer.controller.ts
@@ -140,7 +140,7 @@ export class MailServiceController {
       subject: "「選集」 忘記密碼驗證通知信",
       html: resetPasswordTemplate({
         userName: user.name,
-        resetUrl: `${this.FRONTEND_DOMAIN}/verify-account?token=${token}`,
+        resetUrl: `${this.FRONTEND_DOMAIN}/#/resetpassword?token=${token}`,
       }),
     });
     if (info.accepted.length === 0) {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -18,6 +18,8 @@ const userSchema = new Schema<IUser>(
       },
       index: true,
       unique: true,
+      lowercase: true,
+      trim: true,
       select: false,
     },
     password: {
@@ -32,6 +34,20 @@ const userSchema = new Schema<IUser>(
       },
       select: false,
     },
+    webAuthnCredentials: [{
+    credentialID: {
+      type: Buffer,
+      required: true,
+    },
+    publicKey: {
+      type: String,
+      required: true,
+    },
+    counter: {
+      type: Number,
+      required: true,
+    }
+  }],
     name: {
       type: String,
       minLength: [1, '名稱請大於 1 個字'],
@@ -179,10 +195,6 @@ const userSchema = new Schema<IUser>(
 
 userSchema.pre('save', async function (next)
 {
-  // 如果 email 字段被修改了，則轉換為小寫
-  if (this.isModified('email')) {
-    this.email = this.email.trim().toLowerCase();
-  }
   // 如果密碼被修改了，則對密碼進行加密
   if (this.isModified('password')) {
     const salt = await bcrypt.genSalt(12);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,11 @@ export interface IUser extends Document {
   name: string;
   email: string;
   password: string;
+  webAuthnCredentials: {
+    credentialID: Buffer;
+    publicKey: string;
+    counter: number;
+  }[];
   avatar: string;
   gender: "male" | "female" | "x";
   birthday?: Date;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import jsonWebToken, { type JwtPayload } from 'jsonwebtoken';
-import { date as dateSchema, object } from 'yup';
+import { ObjectSchema, Schema, date as dateSchema, object } from 'yup';
 import { Data, ResponseError } from '@/types';
 import { NextFunction, Request, Response } from 'express';
 
@@ -161,4 +161,17 @@ export const randomPassword = () => {
 
 export const handleErrorAsync = (func: Function) => {
   return (req: Request, res: Response, next: NextFunction) => func(req, res, next).catch((error: Error) => catchError(error, next));
+};
+
+export const validateInput = async (schema: Schema, data, next: NextFunction) => {
+  try {
+    await schema.validate(data);
+    return true;
+  } catch (error: unknown) {
+    if (error instanceof Error && 'errors' in error) {
+      const yupError = error as { errors: string[] };
+      throw appError({ code: 400, message: yupError.errors.join(", "), next });
+    }
+    throw appError({ code: 400, message: '驗證失敗', next });
+  }
 };


### PR DESCRIPTION
功能: 重構認證和驗證機制

- 在 Swagger TypeScript 與 JSON 配置中，將安全定義鍵由 `bearerAuth` 重命名為 `Bearer`
- 在 index.ts 身份驗證路徑中添加 POST 路由 `/auth/reset-password`
- 在 auth.controller.ts 中實現輸入架構驗證並集中驗證邏輯
- 使用新的 `validateInput` 函數來替換 comment.controller.ts 中分散的驗證邏輯
- 利用 `validateInput` 函數來簡化 contact.controller.ts 中的聯繫表單驗證
- 通過使用模組導入優化 Imgur API 整合，並處理相簿 ID 和上傳失敗
- 使用新的重設密碼 URL 模板更新 MailServiceController
- 強制在用戶模型中的電郵欄位使用小寫且去除前後空白；添加 webAuthnCredentials 以支援 WebAuthn
- 在 IUser 介面中引入反映用戶模型變更的 webAuthnCredentials 類型
- 在 utils 中包括集中的輸入驗證工具函數 `validateInput`