### PR TITLE
GIT 提交信息：

### DIFF
--- a/src/controllers/mailer.controller.ts
+++ b/src/controllers/mailer.controller.ts
@@ -1,31 +1,27 @@
 import { RequestHandler } from "express";
-import nodemailer from "nodemailer";
 import validator from "validator";
 import { object, string } from "yup";
-import jwt from "jsonwebtoken";
-import { appError, generateToken, successHandle } from "@/utils";
-import User from "@/models/user";
+import { appError, successHandle } from "@/utils";
+
 import resetPasswordTemplate from "@/views/resetPassword";
+import { AuthService, MailService } from "@/services";
 
 const mailSchema = object().shape({
   from: string(),
   to: string().email().required().required("缺少收件者地址"),
   subject: string().required("缺少主旨"),
-  text: string(),
-  html: string().required("缺少內容"),
+  text: string().required("缺少內容"),
+  html: string(),
 });
 
 export class MailServiceController {
-  public static transporter: nodemailer.Transporter;
-  static FRONTEND_DOMAIN = process.env.FRONTEND_DOMAIN;
-
+  static FRONTEND_DOMAIN = process.env.FRONTEND_DOMAIN || 'http://localhost:3000';
   //SEND MAIL
   public static sendMail: RequestHandler = async (req, res) => {
     mailSchema.validateSync(req.body);
     const { from, to, subject, text, html } = req.body;
-    await MailServiceController.transporter.verify();
-    const info = await MailServiceController.transporter.sendMail({
-      from: `"選集客戶幫助中心" ${process.env.SMTP_SENDER || from}`,
+    const info = await MailService.sendMail({
+      from: `"選集客戶幫助中心" ${process.env.GMAIL_ACCOUNT || from}`,
       to,
       subject,
       text,
@@ -48,8 +44,7 @@ export class MailServiceController {
       subject: "選集會員帳號驗證信",
       html,
     };
-    await MailServiceController.transporter.verify();
-    await MailServiceController.transporter.sendMail(mailConfig);
+    await MailService.sendMail(mailConfig);
   };
 
   public static resendVerificationEmail: RequestHandler = async (
@@ -58,24 +53,8 @@ export class MailServiceController {
     next
   ) => {
     const { email } = req.body;
-    const user = await User.findOne({ email: email.trim().toLowerCase() });
-    if (!user) {
-      throw appError({
-        code: 400,
-        message: "無此帳號，請再次確認註冊 Email 帳號，或是重新註冊新帳號",
-        next,
-      });
-    }
     // 生成新的 token
-    const newVerificationToken = jwt.sign(
-      { userId: user.id },
-      process.env.JWT_SECRET as string,
-      { expiresIn: "24h" } // Token 有效期 24 小时
-    );
-
-    // 更新 user.verificationToken
-    user.verificationToken = newVerificationToken;
-    await user.save();
+    const newVerificationToken = await AuthService.createVerificationToken(email, next);
 
     const verificationUrl = `${process.env.FRONTEND_DOMAIN}/verify-account?token=${newVerificationToken}`;
     const html = `
@@ -95,17 +74,14 @@ export class MailServiceController {
       throw appError({ code: 400, message: "信件格式錯誤", next });
     }
 
-    const transporter = MailServiceController.transporter;
-    await transporter.verify();
-    const info = await transporter.sendMail(mailConfig);
+    const info = await MailService.sendMail(mailConfig);
     successHandle(res, "驗證信已寄出", {
       result: `以成功寄送重新驗證信件至 Email: ${info.accepted}`,
     });
   };
 
   public static sendResetEmail: RequestHandler = async (req, res, next) => {
-    let { email } = req.body;
-    email = email.trim().toLowerCase();
+    const { email } = req.body;
     if (!email) {
       throw appError({
         code: 400,
@@ -120,28 +96,22 @@ export class MailServiceController {
         next,
       });
     }
-    const user = await User.findOne({ email }).exec();
-    if (!user) {
-      throw appError({
-        code: 400,
-        message: "無此帳號，請再次確認註冊 Email 帳號，或是重新註冊新帳號",
-        next,
-      });
-    }
 
-    const token = generateToken({ userId: user.id });
-    await User.findByIdAndUpdate(user.id, { resetToken: token });
+    const [ token, name ] = await AuthService.createResetToken(email, next);
 
-    await MailServiceController.transporter.verify();
-    const info = await MailServiceController.transporter.sendMail({
-      from: `"選集會員服務中心" <${process.env.GMAIL_ACCOUNT}>`,
-      to: `${user.name} <${email}>`,
-      subject: "「選集」 忘記密碼驗證通知信",
-      html: resetPasswordTemplate({
-        userName: user.name,
-        resetUrl: `${this.FRONTEND_DOMAIN}/#/resetpassword?token=${token}`,
-      }),
+    const html = resetPasswordTemplate({
+      userName: name,
+      resetUrl: `${this.FRONTEND_DOMAIN}/#/resetpassword?token=${token}`,
     });
+
+    const mailConfig = {
+      from: `"選集客戶幫助中心" <${process.env.GMAIL_ACCOUNT}>`,
+      to: `${name} <${email}>`,
+      subject: "「選集」 忘記密碼驗證通知信",
+      html,
+    };
+
+    const info = await MailService.sendMail(mailConfig);
     if (info.accepted.length === 0) {
       throw appError({ code: 400, message: "無法寄送信件", next });
     }
@@ -151,12 +121,6 @@ export class MailServiceController {
   };
 }
 
-MailServiceController.transporter = nodemailer.createTransport({
-  service: "gmail",
-  auth: {
-    user: process.env.GMAIL_ACCOUNT,
-    pass: process.env.GMAIL_CLIENT_PASSWORD,
-  },
-});
+
 
 export default MailServiceController;

--- a/src/services/MailService.ts
+++ b/src/services/MailService.ts
@@ -1,0 +1,23 @@
+import nodemailer from "nodemailer";
+
+class MailService {
+  public static transporter: nodemailer.Transporter;
+  static FRONTEND_DOMAIN = process.env.FRONTEND_DOMAIN;
+
+  public static sendMail = async (mailOptions: nodemailer.SendMailOptions) => {
+    await MailService.transporter.verify();
+    const info = await MailService.transporter.sendMail(mailOptions);
+    return info;
+  };
+
+}
+
+MailService.transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.GMAIL_ACCOUNT,
+    pass: process.env.GMAIL_CLIENT_PASSWORD,
+  },
+});
+
+export default MailService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@ export { default as AgendaService } from "./AgendaService";
 export { default as AuthService } from "./AuthService";
 export { default as CommentService } from "./CommentService";
 export { default as ContactService } from "./ContactService";
+export { default as MailService } from "./MailService";
 export { default as MemberService } from "./MemberService";
 export { default as PollService } from "./PollService";
 export { default as TagService } from "./TagService";


### PR DESCRIPTION
重構：重構郵件處理器和抽象化令牌邏輯

- 重構 `mailer.controller.ts`，使之使用新的 `AuthService` 和 `MailService` 類別執行與電子郵件相關的操作。
- 從 `mailer.controller.ts` 移除直接依賴 nodemailer 和 jwt 的部分。
- 調整 `mailer.controller.ts` 中未設置時 `FRONTEND_DOMAIN` 的默認值為 `http://localhost:3000`。
- 在 `mailer.controller.ts` 中的 `mailSchema` 要求來使 `text` 字段為必填，並移除 `html` 字段的要求。
- 將電子郵件驗證令牌和密碼重設令牌生成邏輯抽象化至 `AuthService`。
- 創建一個新檔案 `MailService.ts`，將所有 nodemailer 傳輸配置和郵件傳送邏輯移入其中。
- 在 `services/index.ts` 中註冊 `MailService`，以便在其他地方輕鬆導入。