### PR TITLE
GIT 提交信息：

### DIFF
--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -609,7 +609,7 @@
         }
       }
     },
-    "/api/member/": {
+    "/api/member": {
       "get": {
         "tags": [
           "Member - 會員"
@@ -983,7 +983,7 @@
         ]
       }
     },
-    "/api/poll/": {
+    "/api/poll": {
       "get": {
         "tags": [
           "Poll - 提案"
@@ -1709,7 +1709,7 @@
         ]
       }
     },
-    "/api/tag/": {
+    "/api/tag": {
       "get": {
         "tags": [
           "Tag - 標籤"
@@ -2065,6 +2065,49 @@
               }
             },
             "description": "標籤刪除失敗"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/comment": {
+      "get": {
+        "tags": [
+          "Comment - 評論"
+        ],
+        "description": "獲取使用者所有評論",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "獲取評論成功"
+                },
+                "result": {
+                  "$ref": "#/definitions/Comment"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "獲取評論成功"
+          },
+          "404": {
+            "schema": {
+              "$ref": "#/definitions/ErrorCommentNotFound"
+            },
+            "description": "找不到評論"
           }
         },
         "security": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "passport-github2": "^0.1.12",
     "passport-google-oauth20": "^2.0.0",
     "passport-line-auth": "^0.2.9",
+    "path-to-regexp": "^6.2.1",
     "ramda": "^0.29.1",
     "sirv": "^2.0.4",
     "swagger-ui-express": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   passport-line-auth:
     specifier: ^0.2.9
     version: 0.2.9
+  path-to-regexp:
+    specifier: ^6.2.1
+    version: 6.2.1
   ramda:
     specifier: ^0.29.1
     version: 0.29.1
@@ -4095,6 +4098,10 @@ packages:
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: false
+
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
     dev: false
 
   /pause@0.0.1:

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -41,6 +41,7 @@ app.use(
       { path: '/member', method: 'GET' },
       { path: '/comment', method: 'GET' },
       { path: '/option', method: 'GET' },
+      { path: '/poll/', method: 'GET' },
       { path: '/poll', method: 'GET' },
       { path: '/mail/contact', method: 'POST' },
       { path: '/contact', method: 'POST' },

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -64,6 +64,14 @@ class CommentController {
     const comment = await CommentService.getComment(id, next);
     successHandle(res, "獲取評論成功", { comment });
   };
+
+  // 獲取使用者所有評論
+  public static getComments: RequestHandler = async (req, res, next) =>
+  {
+    const { id } = req.user as IUser;
+    const comments = await CommentService.getCommentByUser(id, next);
+    successHandle(res, "獲取所有評論成功", { comments });
+  };
 }
 
 export default CommentController;

--- a/src/routes/comment.router.ts
+++ b/src/routes/comment.router.ts
@@ -7,6 +7,30 @@ const commentRouter = Router();
 commentRouter.get(
   /**
    * #swagger.tags = ['Comment - 評論']
+   * #swagger.description = '獲取使用者所有評論'
+   * #swagger.path = '/api/comment'
+* #swagger.responses[200] = {
+  schema: {
+    status: true,
+    message: "獲取評論成功",
+    result: { $ref: "#/definitions/Comment" },
+  },
+  description: "獲取評論成功"
+}
+* #swagger.responses[404] = {
+  schema: { $ref: "#/definitions/ErrorCommentNotFound" },
+  description: "找不到評論"
+}
+* #swagger.security = [{
+  "Bearer": []
+}]
+}*/
+  "/",
+  handleErrorAsync(CommentController.getComment)
+);
+commentRouter.get(
+  /**
+   * #swagger.tags = ['Comment - 評論']
    * #swagger.description = '獲取評論'
    * #swagger.path = '/api/comment/{id}'
    * #swagger.parameters['id'] = {

--- a/src/services/CommentService.ts
+++ b/src/services/CommentService.ts
@@ -33,6 +33,19 @@ export class CommentService
     return comment;
   }
 
+  static getCommentByUser = async (id: string, next: NextFunction) =>
+  {
+    const comments = await Comment.find({ author: id }).exec();
+    if (!comments) {
+      throw appError({
+        code: 404,
+        message: "使用者沒有評論",
+        next,
+      });
+    }
+    return comments;
+  }
+
   static updateComment = async (id: string, content: string) =>
   {
     const comment = await Comment.findByIdAndUpdate(


### PR DESCRIPTION
特性：重構 API 並擴展用戶評論路由

- 通過移除對 member、poll 和 tag 端點的結尾斜杠來標準化 API 路徑
- 在 swagger 文檔中引入一個獲取用戶所有評論的路由
- 向 package.json 添加一個新的依賴 `path-to-regexp`
- 在 CommentController 中實現檢索用戶評論的邏輯
- 重構 verifyMiddleware 以支持使用 `path-to-regexp` 的路徑參數
- 將新的 `/poll/` 路徑包含在認證排除中
- 在 `comment.router.ts` 中添加一個獲取所有用戶評論的路由處理程序
- 實現 `getCommentByUser` 服務方法以檢索特定用戶的評論

請記得翻譯所有給定的 git 提交信息。