### PR TITLE
GIT 提交訊息：

### DIFF
--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -84,7 +84,7 @@ class CommentController {
       skip,
       limit
     );
-    successHandle(res, "獲取所有評論成功", { result });
+    successHandle(res, "獲取所有評論成功", { result, total, totalPages, page, limit });
   };
 }
 

--- a/src/controllers/poll.controller.ts
+++ b/src/controllers/poll.controller.ts
@@ -2,7 +2,7 @@ import { NextFunction, RequestHandler, Response } from "express"; // Import miss
 import { appError, successHandle } from "@/utils";
 import { array, boolean, date, object, string } from "yup";
 import { IVote, IUser, IOption, CreatePollRequest } from "@/types";
-import { PollService, TagService, VoteService } from "@/services";
+import { CommentService, PollService, TagService, VoteService } from "@/services";
 
 const pollSchema = object({
   title: string()
@@ -177,7 +177,7 @@ class PollController {
       limit
     );
 
-    successHandle(res, "獲取投票列表成功", { polls, total, page, limit });
+    successHandle(res, "獲取投票列表成功", { polls, total, page, totalPages, limit });
   };
 
   // 根據 ID 獲取投票詳情
@@ -368,6 +368,18 @@ class PollController {
       },
     ]);
     successHandle(res, "結束投票成功", { result: updatedPoll });
+  };
+
+  // 獲取提案中使用者所有評論
+  public static getCommentsByUser: RequestHandler = async (
+    req,
+    res: Response,
+    next
+  ) => {
+    const { id } = req.params;
+    const {id: userId} = req.user as IUser;
+    const comments = await CommentService.getCommentByPollAndUser(id, userId, next);
+    successHandle(res, "獲取使用者評論成功", { result: comments });
   };
 }
 

--- a/src/routes/poll.router.ts
+++ b/src/routes/poll.router.ts
@@ -360,4 +360,42 @@ pollRouter.get(
   handleErrorAsync(PollController.endPoll),
 );
 
+//獲取提案中使用者所有評論
+pollRouter.get(
+  /**
+   * #swagger.tags = ['Poll - 提案']
+   * #swagger.description = '獲取提案中使用者所有評論'
+   * #swagger.path = '/api/poll/{id}/comment/user'
+   * #swagger.parameters['id'] = {
+    in: 'path',
+    required: true,
+    type: 'string',
+    description: '提案ID'
+    }
+   * #swagger.responses[200] = {
+    schema: {
+      status: true,
+      message: "獲取提案評論成功",
+      result: [
+        {
+        $ref: "#/definitions/Comment"
+        }
+      ]
+    },
+    description: "獲取提案評論成功"
+    }
+   * #swagger.responses[404] = {
+    schema: {
+      $ref: "#/definitions/ErrorPollNotFound"
+    },
+    description: "找不到提案"
+    }
+   * #swagger.security = [{
+    "Bearer": []
+    }]
+   */
+  '/:id/comment/user',
+  handleErrorAsync(PollController.getCommentsByUser),
+);
+
 export default pollRouter;

--- a/src/services/CommentService.ts
+++ b/src/services/CommentService.ts
@@ -65,6 +65,35 @@ export class CommentService
     return comments;
   }
 
+  static getCommentByPollAndUser = async (pollId: string, userId: string, next: NextFunction) =>
+  {
+    if (!pollId || !userId) {
+      throw appError({
+        code: 400,
+        message: "缺少必要的參數",
+        next,
+      });
+    }
+    const comments = await Comment.find({ pollId, author: userId })
+      .populate({
+        path: 'pollId',
+        select: 'title id description createdTime status imageUrl tags',
+        populate: {
+          path: 'tags',
+          select: 'name',
+        }
+    })
+    .exec();
+    if (!comments) {
+      throw appError({
+        code: 404,
+        message: "找不到評論",
+        next,
+      });
+    }
+    return comments;
+  }
+
   static updateComment = async (id: string, content: string) =>
   {
     const comment = await Comment.findByIdAndUpdate(


### PR DESCRIPTION
新功能：重構評論和投票數據獲取

- 擴展 `CommentController` 和 `PollController` 中的回應數據，以包含額外的分頁詳情。
- 在 `poll.controller.ts` 中新增導入 `CommentService`。
- 在 `PollController` 中引入新方法 `getCommentsByUser`，以便為特定投票中的用戶抓取評論。
- 在 `poll.router.ts` 中定義新的端點，以從用戶那裡訪問特定投票的評論。
- 在 `CommentService` 中實現 `getCommentByPollAndUser` 服務方法，根據投票和用戶 ID 檢索評論，並且對缺失參數或找不到的評論拋出錯誤。