### PR TITLE
GIT 提交訊息：

### DIFF
--- a/src/services/PollService.ts
+++ b/src/services/PollService.ts
@@ -159,30 +159,32 @@ export class PollService {
     Logger.log("Checking polls...", "INFO");
     const now = new Date();
 
-    await Poll.find({ startDate: { $lte: now }, status: "pending" })
-      .where("status", "active")
-      .updateMany({ status: "active" });
+    // 啟動待開始的投票
+    await Poll.updateMany(
+        { startDate: { $lte: now }, status: "pending" },
+        { status: "active" }
+    );
 
     const totalPollsActivated = await Poll.countDocuments({ status: "active" });
-
     Logger.log(`目前有 ${totalPollsActivated} 筆投票正在進行中`, "INFO");
 
-    await Poll.find({ endDate: { $lte: now }, status: "active" })
-      .where("status", "ended")
-      .updateMany({ status: "ended" });
+    // 更新待結束的投票的狀態
+    await Poll.updateMany(
+        { endDate: { $lte: now }, status: "active" },
+        { status: "ended" }
+    );
 
-    const pollsToEnd = await Poll.find({
-      endDate: { $lte: now },
-      status: "ended",
-    });
+    // 重新查找剛更新為 ended 的投票來進行後續處理
+    const pollsToEnd = await Poll.find({ status: "ended" });
 
     for (let poll of pollsToEnd) {
-      await this.calculateResultsForPoll(poll._id.toString());
+        await this.calculateResultsForPoll(poll._id.toString());
     }
-    const totalPollsToEnd = await Poll.countDocuments({ status: "closed" });
 
+    const totalPollsToEnd = await Poll.countDocuments({ status: "closed" });
     Logger.log(`目前有 ${totalPollsToEnd} 筆投票已經結束`, "INFO");
-  };
+};
+
 
   static startPoll = async (id: string, req, next: NextFunction) => {
     const poll = await Poll.findById(id).exec();


### PR DESCRIPTION
重構：重構並澄清投票啟動流程

- 重構待處理投票的啟動，直接使用 `updateMany` 而非先 `find` 再 `updateMany`
- 針對啟動待處理投票的註解用中文闡明
- 重構活躍投票的停用，直接使用 `updateMany` 而非先 `find` 再 `updateMany`
- 針對停用活躍投票的註解用中文闡明
- 簡化即將結束的投票的檢索過程，直接搜尋狀態為 `ended` 的投票
- 在 `startPollCheckService` 函式宣告後加入空白行以提高可讀性