### PR TITLE
GIT提交訊息：

### DIFF
--- a/develop/ErrorSchema.ts
+++ b/develop/ErrorSchema.ts
@@ -1,16 +1,33 @@
 export const ErrorSchema = {
+  // 通用錯誤
+  ErrorFormat: {
+    status: false,
+    message: "請確認輸入的欄位格式是否正確",
+  },
+  ErrorNotFound: {
+    status: false,
+    message: "請確認 id 是否正確",
+  },
+  ErrorUnauthorized: {
+    status: false,
+    message: "沒有權限進行此操作",
+  },
+  
+  // Token 相關錯誤
   ErrorTokenExpired: {
     status: false,
     message: "Token 已經過期或無效",
   },
   ErrorJsonWebToken: {
     status: false,
-    message: "驗證失敗，請重新登入！",
+    message: "驗證失敗,請重新登入!",
   },
   ErrorTokenNotFound: {
     status: false,
     message: "缺少 Token",
   },
+  
+  // 使用者相關錯誤
   ErrorEmailNotFound: {
     status: false,
     message: "已無此使用者請重新註冊 | 請確認 Email 是否正確 | 此 Email 未註冊",
@@ -21,54 +38,50 @@ export const ErrorSchema = {
   },
   ErrorEmailFormat: {
     status: false,
-    message: "Email 格式有誤，請確認輸入是否正確",
-  },
-  ErrorInputFormat: {
-    status: false,
-    message: "請確認輸入的欄位格式是否正確",
+    message: "Email 格式有誤,請確認輸入是否正確",
   },
   ErrorPasswordFormat: {
     status: false,
     message:
-      "密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元",
+      "密碼強度不足,請確認是否具至少有 1 個數字,1 個大寫英文,1 個小寫英文,1 個特殊符號,且長度至少為 8 個字元",
   },
   ErrorEmailExist: {
-    status: false,
+    status: false, 
     message: "此 Email 已註冊",
-  },
-  ErrorVerificationUrlExpired: {
-    status: false,
-    message: "無效的重設連結或已過期",
-  },
-  ErrorImageFormat: {
-    status: false,
-    message:
-      "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB",
-  },
-  ErrorImageNotFound: {
-    status: false,
-    message: "請上傳檔案",
   },
   ErrorMemberNotFound: {
     status: false,
     message: "無此使用者請確認使用者 id 是否正確",
   },
-  ErrorNoneMemberId: {
+  
+  // 驗證相關錯誤
+  ErrorVerificationUrlExpired: {
     status: false,
-    message: "請提供使用者 id",
+    message: "無效的重設連結或已過期",
   },
+  
+  // 檔案相關錯誤
+  ErrorImageFormat: {
+    status: false,
+    message:
+      "檔案格式錯誤,僅限上傳 jpg、jpeg 與 png 格式。圖片大小不可超過 2MB",
+  },
+  ErrorImageNotFound: {
+    status: false,
+    message: "請上傳檔案",
+  },
+  
+  // 投票相關錯誤  
   ErrorPollNotFound: {
     status: false,
     message: "無此投票請確認提案 id 是否正確",
   },
-  ErrorNonePollId: {
-    status: false,
-    message: "請提供提案 id",
-  },
   ErrorPollValidation: {
     status: false,
-    message: "請確實填寫投票資訊",
+    message: "請確實填寫投票資訊", 
   },
+  
+  // 選項相關錯誤
   ErrorOptionNotFound: {
     status: false,
     message: "無此選項請確認選項 id 是否正確",
@@ -81,6 +94,8 @@ export const ErrorSchema = {
     status: false,
     message: "請確實填寫選項資訊",
   },
+  
+  // 投票相關錯誤
   ErrorVoteExist: {
     status: false,
     message: "您已經對此選項投過票",
@@ -89,18 +104,18 @@ export const ErrorSchema = {
     status: false,
     message: "您尚未對此選項投票",
   },
+  
+  // 留言相關錯誤  
   ErrorCommentNotFound: {
     status: false,
-    message: "無此評論請確認評論 id 是否正確",
+    message: "無此留言請確認留言 id 是否正確",
   },
   ErrorCommentFormat: {
     status: false,
-    message: "請確實填寫評論資訊",
+    message: "請確實填寫留言資訊",
   },
-  ErrorCommentUnauthorized: {
-    status: false,
-    message: "沒有權限更新評論",
-  },
+  
+  // 聯絡相關錯誤
   ErrorContactFormat: {
     status: false,
     message: "請確實填寫聯絡資訊",

--- a/develop/swagger_output.json
+++ b/develop/swagger_output.json
@@ -1559,6 +1559,56 @@
         ]
       }
     },
+    "/api/poll/{id}/comment": {
+      "get": {
+        "tags": [
+          "Poll - 提案"
+        ],
+        "description": "獲取提案評論",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "提案ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "獲取提案評論成功"
+                },
+                "result": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Comment"
+                  }
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "獲取提案評論成功"
+          },
+          "404": {
+            "schema": {
+              "$ref": "#/definitions/ErrorPollNotFound"
+            },
+            "description": "找不到提案"
+          }
+        }
+      }
+    },
     "/api/vote": {
       "post": {
         "tags": [
@@ -2272,19 +2322,19 @@
           },
           "400": {
             "schema": {
-              "$ref": "#/definitions/ErrorCommentFormat"
+              "$ref": "#/definitions/ErrorFormat"
             },
             "description": "請確實填寫評論資訊"
           },
           "403": {
             "schema": {
-              "$ref": "#/definitions/ErrorCommentUnauthorized"
+              "$ref": "#/definitions/ErrorUnauthorized"
             },
             "description": "沒有權限更新評論"
           },
           "404": {
             "schema": {
-              "$ref": "#/definitions/ErrorCommentNotFound"
+              "$ref": "#/definitions/ErrorNotFound"
             },
             "description": "找不到評論"
           }
@@ -2395,9 +2445,245 @@
           },
           "400": {
             "schema": {
-              "$ref": "#/definitions/ErrorCommentFormat"
+              "$ref": "#/definitions/ErrorFormat"
             },
             "description": "請確實填寫評論資訊"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/comment/reply/user": {
+      "get": {
+        "tags": [
+          "Comment - 評論"
+        ],
+        "description": "獲取使用者所有回覆評論",
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "獲取回覆成功"
+                },
+                "result": {
+                  "$ref": "#/definitions/Reply"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "獲取回覆成功"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/comment/{id}/reply": {
+      "post": {
+        "tags": [
+          "Comment - 評論"
+        ],
+        "description": "新增回覆",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "評論ID"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "description": "新增回覆",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "example": "這是一則回覆"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "回覆創建成功"
+                },
+                "result": {
+                  "$ref": "#/definitions/Comment"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "回覆創建成功"
+          },
+          "400": {
+            "schema": {
+              "$ref": "#/definitions/ErrorCommentFormat"
+            },
+            "description": "請確實填寫回覆資訊"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/comment/reply/{id}": {
+      "put": {
+        "tags": [
+          "Comment - 評論"
+        ],
+        "description": "更新回覆",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "回覆ID"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "description": "更新回覆",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "content": {
+                  "type": "string",
+                  "example": "這是一則更新後的回覆"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "回覆更新成功"
+                },
+                "result": {
+                  "$ref": "#/definitions/Comment"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "回覆更新成功"
+          },
+          "400": {
+            "schema": {
+              "$ref": "#/definitions/ErrorFormat"
+            },
+            "description": "請確實填寫回覆資訊"
+          },
+          "403": {
+            "schema": {
+              "$ref": "#/definitions/ErrorUnauthorized"
+            },
+            "description": "沒有權限更新回覆"
+          },
+          "404": {
+            "schema": {
+              "$ref": "#/definitions/ErrorNotFound"
+            },
+            "description": "找不到回覆"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Comment - 評論"
+        ],
+        "description": "刪除回覆",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "回覆ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "message": {
+                  "type": "string",
+                  "example": "回覆刪除成功"
+                }
+              },
+              "xml": {
+                "name": "main"
+              }
+            },
+            "description": "回覆刪除成功"
+          },
+          "403": {
+            "schema": {
+              "$ref": "#/definitions/ErrorUnauthorized"
+            },
+            "description": "沒有權限刪除回覆"
+          },
+          "404": {
+            "schema": {
+              "$ref": "#/definitions/ErrorNotFound"
+            },
+            "description": "找不到回覆"
           }
         },
         "security": [
@@ -3309,6 +3595,45 @@
         }
       }
     },
+    "ErrorFormat": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "請確認輸入的欄位格式是否正確"
+        }
+      }
+    },
+    "ErrorNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "請確認 id 是否正確"
+        }
+      }
+    },
+    "ErrorUnauthorized": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "沒有權限進行此操作"
+        }
+      }
+    },
     "ErrorTokenExpired": {
       "type": "object",
       "properties": {
@@ -3331,7 +3656,7 @@
         },
         "message": {
           "type": "string",
-          "example": "驗證失敗，請重新登入！"
+          "example": "驗證失敗,請重新登入!"
         }
       }
     },
@@ -3383,20 +3708,7 @@
         },
         "message": {
           "type": "string",
-          "example": "Email 格式有誤，請確認輸入是否正確"
-        }
-      }
-    },
-    "ErrorInputFormat": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "boolean",
-          "example": false
-        },
-        "message": {
-          "type": "string",
-          "example": "請確認輸入的欄位格式是否正確"
+          "example": "Email 格式有誤,請確認輸入是否正確"
         }
       }
     },
@@ -3409,7 +3721,7 @@
         },
         "message": {
           "type": "string",
-          "example": "密碼強度不足，請確認是否具至少有 1 個數字， 1 個大寫英文， 1 個小寫英文， 1 個特殊符號，且長度至少為 8 個字元"
+          "example": "密碼強度不足,請確認是否具至少有 1 個數字,1 個大寫英文,1 個小寫英文,1 個特殊符號,且長度至少為 8 個字元"
         }
       }
     },
@@ -3423,6 +3735,19 @@
         "message": {
           "type": "string",
           "example": "此 Email 已註冊"
+        }
+      }
+    },
+    "ErrorMemberNotFound": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "example": false
+        },
+        "message": {
+          "type": "string",
+          "example": "無此使用者請確認使用者 id 是否正確"
         }
       }
     },
@@ -3448,7 +3773,7 @@
         },
         "message": {
           "type": "string",
-          "example": "檔案格式錯誤，僅限上傳 jpg、jpeg 與 png 格式。 圖片大小不可超過 2MB"
+          "example": "檔案格式錯誤,僅限上傳 jpg、jpeg 與 png 格式。圖片大小不可超過 2MB"
         }
       }
     },
@@ -3465,32 +3790,6 @@
         }
       }
     },
-    "ErrorMemberNotFound": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "boolean",
-          "example": false
-        },
-        "message": {
-          "type": "string",
-          "example": "無此使用者請確認使用者 id 是否正確"
-        }
-      }
-    },
-    "ErrorNoneMemberId": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "boolean",
-          "example": false
-        },
-        "message": {
-          "type": "string",
-          "example": "請提供使用者 id"
-        }
-      }
-    },
     "ErrorPollNotFound": {
       "type": "object",
       "properties": {
@@ -3501,19 +3800,6 @@
         "message": {
           "type": "string",
           "example": "無此投票請確認提案 id 是否正確"
-        }
-      }
-    },
-    "ErrorNonePollId": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "boolean",
-          "example": false
-        },
-        "message": {
-          "type": "string",
-          "example": "請提供提案 id"
         }
       }
     },
@@ -3604,7 +3890,7 @@
         },
         "message": {
           "type": "string",
-          "example": "無此評論請確認評論 id 是否正確"
+          "example": "無此留言請確認留言 id 是否正確"
         }
       }
     },
@@ -3617,20 +3903,7 @@
         },
         "message": {
           "type": "string",
-          "example": "請確實填寫評論資訊"
-        }
-      }
-    },
-    "ErrorCommentUnauthorized": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "boolean",
-          "example": false
-        },
-        "message": {
-          "type": "string",
-          "example": "沒有權限更新評論"
+          "example": "請確實填寫留言資訊"
         }
       }
     },

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -6,3 +6,4 @@ export { default as MemberController } from './member.controller';
 export { default as PollController } from './poll.controller';
 export { default as CommentController } from './comment.controller';
 export { default as VoteController } from './vote.controller';
+export { default as ReplyController } from './reply.controller';

--- a/src/controllers/reply.controller.ts
+++ b/src/controllers/reply.controller.ts
@@ -1,0 +1,75 @@
+import { RequestHandler } from "express";
+import { appError, successHandle, validateInput } from "@/utils";
+import { object, string } from "yup";
+import { IUser } from "@/types";
+import { ReplyCommentService } from "@/services";
+
+const commentSchema = object({
+  content: string()
+    .required("請輸入評論內容")
+    .min(1, "評論內容請大於 1 個字")
+    .max(200, "評論內容長度過長，最多只能 200 個字"),
+});
+
+class ReplyController
+{
+  static getReplyByUser: RequestHandler = async (req, res) =>
+  {
+    const { id } = req.user as IUser;
+    const result = await ReplyCommentService.getReplyByUser(id);
+    successHandle(res, "獲取回覆成功", { result });
+  };
+
+  static createReply: RequestHandler = async (req, res, next) =>
+  {
+    const { id } = req.params;
+    const { id: userId } = req.user as IUser;
+    if (!id) throw appError({ code: 400, message: "請輸入評論ID", next });
+    if (!(await validateInput(commentSchema, req.body, next))) return;
+
+    const { content } = req.body;
+
+    const result = await ReplyCommentService.createReply(userId, content, id);
+
+    successHandle(res, "回覆創建成功", { result });
+  };
+
+  static updateReply: RequestHandler = async (req, res, next) =>
+  {
+    const { id } = req.params;
+    const { id: userId } = req.user as IUser;
+    if (!id) throw appError({ code: 400, message: "請輸入回覆ID", next });
+    const reply = await ReplyCommentService.getReply(id);
+    if (!reply) {
+      throw appError({ code: 404, message: "找不到回覆", next });
+    }
+    if (reply.author.id !== userId) {
+      throw appError({ code: 403, message: "沒有權限更新回覆", next });
+    }
+    if (!(await validateInput(commentSchema, req.body, next))) return;
+
+    const { content } = req.body;
+    const result = await ReplyCommentService.updateReply(id, content);
+
+    successHandle(res, "回覆更新成功", { result });
+  };
+
+  static deleteReply: RequestHandler = async (req, res, next) =>
+  {
+    const { id } = req.params;
+    const { id: userId } = req.user as IUser;
+    if (!id) throw appError({ code: 400, message: "請輸入回覆ID", next });
+    const reply = await ReplyCommentService.getReply(id);
+    if (!reply) {
+      throw appError({ code: 404, message: "找不到回覆", next });
+    }
+    if (reply.author.id !== userId) {
+      throw appError({ code: 403, message: "沒有權限刪除回覆", next });
+    }
+    const result = await ReplyCommentService.deleteReply(id);
+
+    successHandle(res, "回覆刪除成功", { result });
+  };
+}
+
+export default ReplyController;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,3 +5,4 @@ export { default as Tag } from './tag';
 export { default as TokenBlacklist } from './tokenBlacklist';
 export { default as User } from './user';
 export { default as Vote } from './vote';
+export { default as Reply } from './replyComment';

--- a/src/models/replyComment.ts
+++ b/src/models/replyComment.ts
@@ -1,0 +1,64 @@
+import { Schema, model } from 'mongoose';
+import { IComment } from '@/types';
+
+const replySchema = new Schema<IComment>({
+  content: {
+    type: String,
+    required: true,
+    minLength: 1,
+    maxLength: 200
+  },
+  author: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  },
+  edited: {
+    type: Boolean,
+    default: false,
+  },
+  createdTime: {
+    type: Date,
+    default: Date.now
+  },
+  updateTime: {
+    type: Date,
+    default: Date.now
+  },
+  replies: [ {
+    type: Schema.Types.ObjectId,
+    ref: 'Reply',
+  }]
+}, {
+  timestamps: { createdAt: 'createdTime', updatedAt: 'updateTime' },
+  versionKey: false,
+  toJSON: {
+    virtuals: true,
+    transform: function (_doc, ret)
+    {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  },
+  toObject: {
+    virtuals: true,
+    transform: function (_doc, ret)
+    {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  },
+});
+
+replySchema.pre(/^find/, function(next) {
+  (this as IComment).populate([{
+    path: 'author',
+    select: 'name avatar'
+  }]);
+  next();
+});
+
+
+replySchema.index({ author: 1 });
+
+export default model<IComment>('Reply', replySchema);

--- a/src/routes/comment.router.ts
+++ b/src/routes/comment.router.ts
@@ -1,4 +1,4 @@
-import CommentController from "@/controllers/comment.controller";
+import { ReplyController, CommentController } from "@/controllers";
 import { handleErrorAsync } from "@/utils";
 import { Router } from "express";
 
@@ -80,7 +80,7 @@ commentRouter.post(
   description: "評論創建成功"
 }
 * #swagger.responses[400] = {
-  schema: { $ref: "#/definitions/ErrorCommentFormat" },
+  schema: { $ref: "#/definitions/ErrorFormat" },
   description: "請確實填寫評論資訊"
 }
 * #swagger.security = [{
@@ -120,15 +120,15 @@ commentRouter.put(
   description: "評論更新成功"
 }
 * #swagger.responses[404] = {
-  schema: { $ref: "#/definitions/ErrorCommentNotFound" },
+  schema: { $ref: "#/definitions/ErrorNotFound" },
   description: "找不到評論"
 }
 * #swagger.responses[403] = {
-  schema: { $ref: "#/definitions/ErrorCommentUnauthorized" },
+  schema: { $ref: "#/definitions/ErrorUnauthorized" },
   description: "沒有權限更新評論"
 }
 * #swagger.responses[400] = {
-  schema: { $ref: "#/definitions/ErrorCommentFormat" },
+  schema: { $ref: "#/definitions/ErrorFormat" },
   description: "請確實填寫評論資訊"
 }
 * #swagger.security = [{
@@ -167,5 +167,152 @@ commentRouter.delete(
   "/:id",
   handleErrorAsync(CommentController.deleteComment)
 );
+
+commentRouter.get(
+  /**
+   * #swagger.tags = ['Comment - 評論']
+   * #swagger.description = '獲取使用者所有回覆評論'
+   * #swagger.path = '/api/comment/reply/user'
+   * #swagger.responses[200] = {
+      schema: {
+        status: true,
+        message: "獲取回覆成功",
+        result: { $ref: "#/definitions/Reply" },
+      },
+      description: "獲取回覆成功"
+    }
+    * #swagger.security = [{
+      "Bearer": []
+    }]
+    */
+  "/reply/user",
+  handleErrorAsync(ReplyController.getReplyByUser)
+);
+
+// 新增回覆
+commentRouter.post(
+  /**
+   * #swagger.tags = ['Comment - 評論']
+   * #swagger.description = '新增回覆'
+   * #swagger.path = '/api/comment/{id}/reply'
+   * #swagger.parameters['id'] = {
+      in: 'path',
+      required: true,
+      type: 'string',
+      description: '評論ID'
+    }
+    * #swagger.parameters['body'] = {
+      in: 'body',
+      required: true,
+      type: 'object',
+      description: '新增回覆',
+      schema: {
+        content: '這是一則回覆'
+      }
+    }
+    * #swagger.responses[200] = {
+      schema: {
+        status: true,
+        message: "回覆創建成功",
+        result: { $ref: "#/definitions/Comment" },
+      },
+      description: "回覆創建成功"
+    }
+    * #swagger.responses[400] = {
+      schema: { $ref: "#/definitions/ErrorCommentFormat" },
+      description: "請確實填寫回覆資訊"
+    }
+    * #swagger.security = [{
+      "Bearer": []
+    }]
+    */
+  "/:id/reply",
+  handleErrorAsync(ReplyController.createReply)
+);
+
+// 更新回覆
+commentRouter.put(
+  /**
+   * #swagger.tags = ['Comment - 評論']
+   * #swagger.description = '更新回覆'
+   * #swagger.path = '/api/comment/reply/{id}'
+   * #swagger.parameters['id'] = {
+      in: 'path',
+      required: true,
+      type: 'string',
+      description: '回覆ID'
+    }
+    * #swagger.parameters['body'] = {
+      in: 'body',
+      required: true,
+      type: 'object',
+      description: '更新回覆',
+      schema: {
+        content: '這是一則更新後的回覆'
+      }
+    }
+    * #swagger.responses[200] = {
+      schema: {
+        status: true,
+        message: "回覆更新成功",
+        result: { $ref: "#/definitions/Comment" },
+      },
+      description: "回覆更新成功"
+    }
+    * #swagger.responses[404] = {
+      schema: { $ref: "#/definitions/ErrorNotFound" },
+      description: "找不到回覆"
+    }
+    * #swagger.responses[403] = {
+      schema: { $ref: "#/definitions/ErrorUnauthorized" },
+      description: "沒有權限更新回覆"
+    }
+    * #swagger.responses[400] = {
+      schema: { $ref: "#/definitions/ErrorFormat" },
+      description: "請確實填寫回覆資訊"
+    }
+    * #swagger.security = [{
+      "Bearer": []
+    }]
+    */
+  "/reply/:id",
+  handleErrorAsync(ReplyController.updateReply)
+);
+
+// 刪除回覆
+commentRouter.delete(
+  /**
+   * #swagger.tags = ['Comment - 評論']
+   * #swagger.description = '刪除回覆'
+   * #swagger.path = '/api/comment/reply/{id}'
+   * #swagger.parameters['id'] = {
+      in: 'path',
+      required: true,
+      type: 'string',
+      description: '回覆ID'
+    }
+    * #swagger.responses[200] = {
+      schema: {
+        status: true,
+        message: "回覆刪除成功",
+      },
+      description: "回覆刪除成功"
+    }
+    * #swagger.responses[404] = {
+      schema: { $ref: "#/definitions/ErrorNotFound" },
+      description: "找不到回覆"
+    }
+    * #swagger.responses[403] = {
+      schema: { $ref: "#/definitions/ErrorUnauthorized" },
+      description: "沒有權限刪除回覆"
+    }
+    * #swagger.security = [{
+      "Bearer": []
+    }]
+    */
+  "/reply/:id",
+  handleErrorAsync(ReplyController.deleteReply)
+);
+
 
 export default commentRouter;

--- a/src/services/ReplyCommentService.ts
+++ b/src/services/ReplyCommentService.ts
@@ -1,0 +1,90 @@
+import { Comment, Reply } from "@/models";
+import { IComment } from "@/types";
+import { FilterQuery } from "mongoose";
+
+export class ReplyCommentService
+{
+  static countDocuments = async (query: FilterQuery<IComment>) =>
+    Reply.countDocuments(query).exec();
+  
+  static getReply = async (id: string) => Reply.findById(id)
+      .select('content createdTime edited updateTime')
+      .populate({
+        path: 'commentId',
+        select: 'content createdTime edited updateTime',
+        populate: {
+          path: 'pollId',
+          select: 'title id',
+        },
+      }).exec();
+  
+  static getReplyByUser = async (id: string) =>
+  {
+    const result = await Reply.find({ author: id })
+      .select('content createdTime edited updateTime')
+      .populate({
+        path: 'commentId',
+        select: 'content createdTime edited updateTime',
+        populate: {
+          path: 'pollId',
+          select: 'title id',
+        },
+      });
+    return result;
+  }
+
+  static createReply = async (author: string, content: string, commentId: string) =>
+  {
+    const reply = await Reply.create({
+      author,
+      content,
+      commentId,
+    });
+    const result = await Comment.findByIdAndUpdate(
+      commentId,
+      {
+        $push: {
+          replies: reply._id,
+        },
+      },
+      { new: true }
+    ).populate({
+    path: 'replies',
+    select: 'content author createdTime edited updateTime',
+    populate: {
+      path: 'author',
+      select: 'name avatar',
+    },
+  });
+    return result;
+  }
+
+  static updateReply = async (id: string, content: string) =>
+  {
+    const result = await Reply.findByIdAndUpdate(
+      id,
+      {
+        content,
+        edited: true,
+        updateTime: new Date(),
+      },
+      { new: true }
+    );
+    return result;
+  }
+
+  static deleteReply = async (id: string) =>
+  {
+    const reply = await Reply.findById(id);
+    if (!reply) return null;
+    const result = await Comment.findByIdAndUpdate(id, {
+      $pull: {
+        replies: id,
+      },
+    });
+    await Reply.findByIdAndDelete(id);
+    return result;
+  }
+}
+
+export default ReplyCommentService;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,3 +10,4 @@ export { default as thirdPartyAuthService } from "./ThirdPartyService";
 export { default as TokenBlackListService } from "./TokenBlackListService";
 export { default as VoteService } from "./VoteService";
 export { default as webSocketService } from "./webSocketService";
+export { default as ReplyCommentService } from "./ReplyCommentService";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,6 +146,7 @@ export interface IComment extends Document {
   createdTime: Date;
   edited: boolean;
   updateTime: Date;
+  replies: IComment[];
 }
 
 export interface ITag extends Document {


### PR DESCRIPTION
feat: 加強評論功能與錯誤處理

- 在`ErrorSchema.ts`中新增通用錯誤代碼，用於格式錯誤、未找到及未授權錯誤
- 將`ErrorSchema.ts`中錯誤訊息的標點符號從全形改為半形
- 移除一些錯誤代碼，例如`ErrorNoneMemberId`和`ErrorNonePollId`
- 為Swagger API文件新增端點，以用於抓取和管理對評論的回覆
- 實作一個新的`ReplyController`來處理評論的回覆功能
- 創建一個新的`replyComment`模型，用於在資料庫中表示對評論的回覆
- 修改`comment`模型，增加一個用於回覆的參考欄位
- 更新路由以包含評論回覆操作的新端點
- 實作`ReplyCommentService`以提供與回覆相關的業務邏輯操作