### PR TITLE
GIT 提交訊息：

### DIFF
--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -100,6 +100,7 @@ class CommentController {
     );
     successHandle(res, "獲取所有評論成功", { result, total, totalPages, page, limit });
   };
+
 }
 
 export default CommentController;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -155,11 +155,8 @@ const userSchema = new Schema<IUser>(
     ],
     comments: [
       {
-        _id: false,
-        comment: {
-          type: Schema.Types.ObjectId,
-          ref: 'Comment',
-        },
+        type: Schema.Types.ObjectId,
+        ref: 'Comment',
       },
     ]
   },


### PR DESCRIPTION
功能：重構評論系統與錯誤處理

- 在 `CommentController` 類別定義後新增空白行，以便於樣式設定。
- 通過移除非必需的嵌套結構來簡化 User 模型中的 `comments` 欄位。
- 更新 `CommentService`，在儲存回覆時將評論 ID 添加到 User 模型中。
- 重構 `CommentService` 中的 `deleteComment` 方法，在刪除前檢查評論擁有權，並從相關投票和回覆中移除評論。
- 實現錯誤處理，在嘗試刪除不存在的評論或用戶缺乏權限時進行處理。