### PR TITLE
GIT 提交訊息：

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -68,7 +68,7 @@ const userSchema = new Schema<IUser>(
     birthday: {
       type: Date,
     },
-    followers: [
+    followedUsers: [
       {
         _id: false,
         user: { type: Schema.Types.ObjectId, ref: "User" },
@@ -78,7 +78,7 @@ const userSchema = new Schema<IUser>(
         },
       },
     ],
-    following: [
+    followingUsers: [
       {
         _id: false,
         user: { type: Schema.Types.ObjectId, ref: "User" },
@@ -164,12 +164,6 @@ const userSchema = new Schema<IUser>(
         ref: "Comment",
       },
     ],
-    followPolls: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: "Poll",
-      },
-    ],
   },
   {
     versionKey: false,
@@ -212,7 +206,7 @@ userSchema.post("save", async function () {
   if (this.isModified("followers")) {
     customEmitter.emit("userUpdated", {
       userId: this._id,
-      followers: this.followers,
+      followers: this.followedUsers,
     });
   }
 });

--- a/src/routes/poll.router.ts
+++ b/src/routes/poll.router.ts
@@ -376,7 +376,7 @@ pollRouter.get(
 )
 
 // 取消追蹤提案
-pollRouter.get(
+pollRouter.delete(
   /**
    * #swagger.tags = ['Poll - 提案']
    * #swagger.description = '取消追蹤提案'
@@ -407,7 +407,7 @@ pollRouter.get(
     "Bearer": []
     }]
    */
-  '/:id/un-follow',
+  '/:id/follow',
   handleErrorAsync(PollController.unFollowPoll),
 )
 

--- a/src/services/MemberService.ts
+++ b/src/services/MemberService.ts
@@ -53,22 +53,22 @@ class MemberService
     await modelFindByID("User", id);
     const user = await User.findById(id) as IUser;
     const isAlreadyFollowing =
-      user.following &&
-      user.following.some(
+      user.followingUsers &&
+      user.followingUsers.some(
         (following) => following.user.id.toString() === targetID
       );
     if (isAlreadyFollowing)
       throw appError({ code: 400, message: "您已經追蹤了該使用者", next });
 
     const resultUserData = await User.findOneAndUpdate(
-      { id, "following.user": { $ne: targetID } },
-      { $addToSet: { following: { user: targetID } } },
+      { id, "followingUsers.user": { $ne: targetID } },
+      { $addToSet: { followingUsers: { user: targetID } } },
       { new: true }
     ).select("-coin -updatedAt -isValidator -isSubscribed");
 
     await User.findOneAndUpdate(
       { id: targetID },
-      { $addToSet: { followers: { user: id } } }
+      { $addToSet: { followedUsers: { user: id } } }
     );
     return resultUserData;
   }
@@ -79,8 +79,8 @@ class MemberService
     const user = await User.findById(id) as IUser;
 
     const isFollowing =
-      user.following &&
-      user.following.some(
+      user.followingUsers &&
+      user.followingUsers.some(
         (following) => following.user.id.toString() === targetID
       );
     if (!isFollowing)
@@ -92,12 +92,12 @@ class MemberService
 
     await User.findOneAndUpdate(
       { id: id },
-      { $pull: { following: { user: targetID } } }
+      { $pull: { followingUsers: { user: targetID } } }
     );
 
     await User.findOneAndUpdate(
       { id: targetID },
-      { $pull: { followers: { user: id } } }
+      { $pull: { followedUsers: { user: id } } }
     );
 
     return true;

--- a/src/services/PollService.ts
+++ b/src/services/PollService.ts
@@ -31,7 +31,7 @@ export class PollService {
   ) => {
     return await Poll.find(queryConditions)
       .sort(sort || { createdAt: -1 })
-      .select("-comments -options -followers -isWinner -updatedAt")
+      .select("-comments -options -like -isWinner -updatedAt")
       .skip(skip)
       .limit(limit)
       .exec();
@@ -178,14 +178,15 @@ export class PollService {
       = await User.findById(userId).exec() as IUser;
     await modelExists("Poll", pollId, userId, "followers", '尚未追蹤', true);
     const result = await Poll.findOneAndUpdate(
-      { id: pollId },
+      { _id: pollId },
       { $pull: { followers: user._id } },
       { new: true }
     )
       .populate("followers", "name avatar")
       .exec();
+    console.log(result);
     await User.findOneAndUpdate(
-      { id: userId },
+      { _id: userId },
       { $pull: { followedPolls: { poll } } },
       { new: true }
     ).exec();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,11 +34,11 @@ export interface IUser extends Document {
       id: string;
     }
   ];
-  followers?: {
+  followedUsers?: {
     user: IUser["_id"];
     createdAt: Date;
   }[];
-  following?: {
+  followingUsers?: {
     user: IUser["_id"];
     createdAt: Date;
   }[];

--- a/src/utils/modelCheck.ts
+++ b/src/utils/modelCheck.ts
@@ -37,7 +37,6 @@ export async function modelExists(
   }
   targetName = model === 'User' ? '使用者' : model === 'Poll' ? '提案' : model === 'Comment' ? '評論' : model === 'Tag' ? '標籤' : '選項';
   const result = await models(model).findOne({ _id: modelId, [ target ]: id }).exec() as ModelSelect<ModelType>;
-  console.log(result);
   checkExists(result);
   return result;
 }


### PR DESCRIPTION
重構：重構用戶關注系統及路由

- 在用戶模型和類型中，將 `followers` 陣列重命名為 `followedUsers`。
- 在用戶模型和類型中，將 `following` 陣列重命名為 `followingUsers`。
- 從用戶模型中移除 `followPolls` 陣列。
- 發出 `userUpdated` 事件時，使用 `followedUsers` 替代 `followers`。
- 將 `pollRouter.get` 方法改為 `pollRouter.delete`，用於取消關注路由，並修復路徑重複問題。
- 在 MemberService 中，更新方法以使用 `followingUsers` 和 `followedUsers` 進行關注/取消關注操作。
- 從 `PollService.ts` 中移除一條 console.log 語句。
- 更新 `PollService.findPolls` 方法中的選擇字段，將 `-followers` 替換為 `-like`。
- 調整幾個模型更新條件（使用 `_id` 替代 `id`）。
- 從 `modelCheck.ts` 中移除一條不必要的 console.log 語句。